### PR TITLE
improve ADFS compatibility

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -115,7 +115,7 @@ SAML.prototype.certToPEM = function (cert) {
 SAML.prototype.validateSignature = function (xml, cert) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath.SelectNodes(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xmlCrypto.xpath.SelectNodes(doc, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {


### PR DESCRIPTION
I'm using passport-saml with ADFS.

My ADFS produces SAML with enveloped signatures where the Signature node is three levels down, and the existing XPath in validateSignature is only looking for Signature nodes two levels down.

As far as I can tell from the SAML spec, the Signature node is allowed anywhere in the document. I validated both SAML from ADFS and feide.no against the XSD schemas provided alongside the SAML spec.
