### PR TITLE
add NameID to profile, 2 bug fixes

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -53,7 +53,7 @@ SAML.prototype.signRequest = function (xml) {
   return signer.sign(this.options.privateCert, 'base64');
 }
 
-SAML.prototype.generateRequest = function (req) {
+SAML.prototype.generateAuthorizeRequest = function (req) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
 
@@ -65,11 +65,14 @@ SAML.prototype.generateRequest = function (req) {
   }
 
   var request =
-   "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\"" + instant + "\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"" + callbackUrl + "\" Destination=\"" + this.options.entryPoint + "\">" +
+   "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\"" + instant + 
+   "\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"" + callbackUrl + "\" Destination=\"" + 
+   this.options.entryPoint + "\">" +
     "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + this.options.issuer + "</saml:Issuer>\n";
 
   if (this.options.identifierFormat) {
-    request += "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"" + this.options.identifierFormat + "\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n";
+    request += "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"" + this.options.identifierFormat + 
+    "\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n";
   }
    
   request += 
@@ -80,17 +83,41 @@ SAML.prototype.generateRequest = function (req) {
   return request;
 };
 
-SAML.prototype.getAuthorizeUrl = function (req, callback) {
+SAML.prototype.generateLogoutRequest = function (req) {
+  var id = "_" + this.generateUniqueID();
+  var instant = this.generateInstant();
+
+  //samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" 
+  // ID="_135ad2fd-b275-4428-b5d6-3ac3361c3a7f" Version="2.0" Destination="https://idphost/adfs/ls/" 
+  //IssueInstant="2008-06-03T12:59:57Z"><saml:Issuer>myhost</saml:Issuer><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" 
+  //NameQualifier="https://idphost/adfs/ls/">myemail@mydomain.com</NameID<samlp:SessionIndex>_0628125f-7f95-42cc-ad8e-fde86ae90bbe
+  //</samlp:SessionIndex></samlp:LogoutRequest>
+
+  var request = "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" "+
+    "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\""+id+"\" Version=\"2.0\" IssueInstant=\""+instant+
+    "\" Destination=\""+this.options.entryPoint + "\">" +
+    "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + this.options.issuer + "</saml:Issuer>"+
+    "<saml:NameID Format=\""+req.user.nameIDFormat+"\">"+req.user.nameID+"</saml:NameID>"+
+    "</samlp:LogoutRequest>";
+  return request;
+}
+
+SAML.prototype.requestToUrl = function (request, operation, callback) {
   var self = this;
-  var request = this.generateRequest(req);
   zlib.deflateRaw(request, function(err, buffer) {
     if (err) {
       return callback(err);
     }
 
-    var base64   = buffer.toString('base64');
-    var target = self.options.entryPoint + '?'
+    var base64 = buffer.toString('base64');
+    var target = self.options.entryPoint + '?';
 
+    if (operation === 'logout') {
+      if (self.options.logoutUrl) {
+        target = self.options.logoutUrl + '?';
+      } 
+    }
+ 
     var samlRequest = {
       SAMLRequest: base64
     };
@@ -103,7 +130,19 @@ SAML.prototype.getAuthorizeUrl = function (req, callback) {
 
     callback(null, target);
   });
+}
+
+SAML.prototype.getAuthorizeUrl = function (req, callback) {
+  var request = this.generateAuthorizeRequest(req);
+  
+  this.requestToUrl(request, 'authorize', callback);
 };
+
+SAML.prototype.getLogoutUrl = function(req, callback) {
+  var request = this.generateLogoutRequest(req);
+
+  this.requestToUrl(request, 'logout', callback);
+}
 
 SAML.prototype.certToPEM = function (cert) {
   cert = cert.match(/.{1,64}/g).join('\n');
@@ -132,72 +171,88 @@ SAML.prototype.validateSignature = function (xml, cert) {
 SAML.prototype.getElement = function (parentElement, elementName) {
   if (parentElement['saml:' + elementName]) {
     return parentElement['saml:' + elementName];
-  }
+  } else if (parentElement['samlp:'+elementName]) {
+    return parentElement['samlp:'+elementName];
+  } 
   return parentElement[elementName];
 }
 
 SAML.prototype.validateResponse = function (samlResponse, callback) {
   var self = this;
   var xml = new Buffer(samlResponse, 'base64').toString('ascii');
-  var parser = new xml2js.Parser();
+  var parser = new xml2js.Parser({explicitRoot:true});
   parser.parseString(xml, function (err, doc) {
     // Verify signature
     if (self.options.cert && !self.validateSignature(xml, self.options.cert)) {
-      return callback(new Error('Invalid signature'), null);
+      return callback(new Error('Invalid signature'), null, false);
     }
 
-    var assertion = self.getElement(doc, 'Assertion');
-    if (!assertion) {
-      return callback(new Error('Missing SAML assertion'), null);
-    }
+    var response = self.getElement(doc, 'Response');
+    if (response) {
+      var assertion = self.getElement(response, 'Assertion');
+      if (!assertion) {
+        return callback(new Error('Missing SAML assertion'), null, false);
+      }
 
-    profile = {};
-    profile.issuer = self.getElement(assertion, 'Issuer');
+      profile = {};
+      var issuer = self.getElement(assertion[0], 'Issuer');
+      if (issuer) {
+        profile.issuer = issuer[0];
+      }
 
-    var subject = self.getElement(assertion, 'Subject');
-    if (subject) {
-      var nameID = self.getElement(subject, 'NameID');
-      if (nameID) {
-        if (typeof nameID === 'string') {
-          profile.nameID = nameID;  
-        } else {
-          profile.nameID = nameID["#"];
+      var subject = self.getElement(assertion[0], 'Subject');
+      if (subject) {
+        var nameID = self.getElement(subject[0], 'NameID');
+        if (nameID) {
+            profile.nameID = nameID[0]["_"];
+
+          if (nameID[0]['$'].Format) {
+            profile.nameIDFormat = nameID[0]['$'].Format;
+          }
         }
       }
-    }
 
-    var attributeStatement = self.getElement(assertion, 'AttributeStatement');
-    if (!attributeStatement) {
-      return callback(new Error('Missing AttributeStatement'), null);
-    }
-
-    var attributes = self.getElement(attributeStatement, 'Attribute');
-
-    var eachAttributeValue = function (attribute) {
-      var value = self.getElement(attribute, 'AttributeValue');
-      if (typeof value === 'string') {
-        profile[attribute['@'].Name] = value;
-        return;
+      var attributeStatement = self.getElement(assertion[0], 'AttributeStatement');
+      if (!attributeStatement) {
+        return callback(new Error('Missing AttributeStatement'), null, false);
       }
-      profile[attribute['@'].Name] = value['#'];
-    };
 
-    if (attributes.forEach) {
-      attributes.forEach(eachAttributeValue);
+      var attributes = self.getElement(attributeStatement[0], 'Attribute');
+
+      if (attributes) {
+        attributes.forEach(function (attribute) {
+          var value = self.getElement(attribute, 'AttributeValue');
+          if (typeof value[0] === 'string') {
+            profile[attribute['$'].Name] = value[0];
+          } else {
+            profile[attribute['$'].Name] = value[0]['_'];
+          }
+        });
+      }
+        
+
+      if (!profile.mail && profile['urn:oid:0.9.2342.19200300.100.1.3']) {
+        // See http://www.incommonfederation.org/attributesummary.html for definition of attribute OIDs
+        profile.mail = profile['urn:oid:0.9.2342.19200300.100.1.3'];
+      }
+
+      if (!profile.email && profile.mail) {
+        profile.email = profile.mail;
+      }
+
+      callback(null, profile, false);
     } else {
-      eachAttributeValue(attributes);
+      var logoutResponse = self.getElement(doc, 'LogoutResponse');
+
+      if (logoutResponse){
+        callback(null, null, true);
+      } else {
+        return callback(new Error('Unknown SAML response message'), null, false);
+      }
+
     }
 
-    if (!profile.mail && profile['urn:oid:0.9.2342.19200300.100.1.3']) {
-      // See http://www.incommonfederation.org/attributesummary.html for definition of attribute OIDs
-      profile.mail = profile['urn:oid:0.9.2342.19200300.100.1.3'];
-    }
 
-    if (!profile.email && profile.mail) {
-      profile.email = profile.mail;
-    }
-
-    callback(null, profile);
   });
 };
 

--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -28,9 +28,19 @@ Strategy.prototype.authenticate = function (req, options) {
     // We have a response, get the user identity out of it
     var response = req.body.SAMLResponse;
 
-    this._saml.validateResponse(response, function (err, profile) {
+    this._saml.validateResponse(response, function (err, profile, loggedOut) {
       if (err) {
         return self.error(err);
+      }
+
+      if (loggedOut) {
+        if (self._saml.options.logoutRedirect) {
+          self.redirect(self._saml.options.logoutRedirect);
+          return;  
+        } else {
+          self.redirect("/");          
+        }
+        
       }
 
       var verified = function (err, user, info) {
@@ -58,6 +68,10 @@ Strategy.prototype.authenticate = function (req, options) {
       self.redirect(url);
     });
   }
+};
+
+Strategy.prototype.logout = function(req, callback) {
+  this._saml.getLogoutUrl(req, callback);
 };
 
 module.exports = Strategy;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "passport": "0.1.x",
     "zlib": "1.0.x",
-    "xml2js": "0.1.x",
+    "xml2js": "0.2.0",
     "xml-crypto": "0.0.x",
     "xmldom": "0.1.x"
   },


### PR DESCRIPTION
 if the SAML response includes a NameID, put it in the profile
only one claim in the SAML response shouldn't cause an error

in certain cases, a SAML response from ADFS might not contain any AttributeStatement.  return a specific error for this problem.
