### PR TITLE
Build issues caused by zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "main": "./lib/passport-saml",
   "dependencies": {
     "passport": "0.1.x",
-    "zlib": "1.0.x",
     "xml2js": "0.2.0",
     "xml-crypto": "0.0.x",
     "xmldom": "0.1.x"


### PR DESCRIPTION
When installing passport-saml using node 0.8.8, I was seeing the error message copied below. This was caused by the non-native use of zlib and the problems that node-waf can have with 0.8+ installs. Stripping out the zlib dependency and using the native Node.js zlib API (http://nodejs.org/api/zlib.html) instead seems to do the trick. I've verified the fix using http://openidp.feide.no/.

```
npm info install passport-saml@0.0.4 into /opt/Hilary
npm info installOne passport-saml@0.0.4
npm info /opt/Hilary/node_modules/passport-saml unbuild
npm info preinstall passport-saml@0.0.4
npm info retry registry request attempt 1 at 12:45:18
npm http GET https://registry.npmjs.org/zlib
npm info retry registry request attempt 1 at 12:45:18
npm http GET https://registry.npmjs.org/xml2js/0.2.0
npm info retry registry request attempt 1 at 12:45:18
npm http GET https://registry.npmjs.org/xml-crypto
npm info retry registry request attempt 1 at 12:45:18
npm http GET https://registry.npmjs.org/xmldom
npm http 304 https://registry.npmjs.org/zlib
npm http 304 https://registry.npmjs.org/xml2js/0.2.0
npm http 304 https://registry.npmjs.org/xml-crypto
npm http 304 https://registry.npmjs.org/xmldom
npm info install zlib@1.0.5 into /opt/Hilary/node_modules/passport-saml
npm info install xml2js@0.2.0 into /opt/Hilary/node_modules/passport-saml
npm info install xml-crypto@0.0.10 into /opt/Hilary/node_modules/passport-saml
npm info install xmldom@0.1.13 into /opt/Hilary/node_modules/passport-saml
npm info installOne zlib@1.0.5
npm info installOne xml2js@0.2.0
npm info installOne xml-crypto@0.0.10
npm info installOne xmldom@0.1.13
npm info /opt/Hilary/node_modules/passport-saml/node_modules/zlib unbuild
npm info /opt/Hilary/node_modules/passport-saml/node_modules/xml2js unbuild
npm info /opt/Hilary/node_modules/passport-saml/node_modules/xml-crypto unbuild
npm info /opt/Hilary/node_modules/passport-saml/node_modules/xmldom unbuild
npm info preinstall xml2js@0.2.0
npm info retry registry request attempt 1 at 12:45:19
npm http GET https://registry.npmjs.org/sax
npm info preinstall zlib@1.0.5
npm info build /opt/Hilary/node_modules/passport-saml/node_modules/zlib
npm info linkStuff zlib@1.0.5
npm info install zlib@1.0.5

> zlib@1.0.5 install /opt/Hilary/node_modules/passport-saml/node_modules/zlib
> node-waf clean ; node-waf configure build

npm info preinstall xml-crypto@0.0.10
npm info build /opt/Hilary/node_modules/passport-saml/node_modules/xml-crypto
npm info linkStuff xml-crypto@0.0.10
npm info install xml-crypto@0.0.10
npm info postinstall xml-crypto@0.0.10
npm info preinstall xmldom@0.1.13
npm info build /opt/Hilary/node_modules/passport-saml/node_modules/xmldom
npm info linkStuff xmldom@0.1.13
npm info install xmldom@0.1.13
npm info postinstall xmldom@0.1.13
Nothing to clean (project not configured)
npm http 304 https://registry.npmjs.org/sax
npm info install sax@0.5.1 into /opt/Hilary/node_modules/passport-saml/node_modules/xml2js
npm info installOne sax@0.5.1
npm info /opt/Hilary/node_modules/passport-saml/node_modules/xml2js/node_modules/sax unbuild
Setting srcdir to                        : /opt/Hilary/node_modules/passport-saml/node_modules/zlib 
Setting blddir to                        : /opt/Hilary/node_modules/passport-saml/node_modules/zlib/build 
Checking for program g++ or c++          : /usr/bin/g++ 
Checking for program cpp                 : /usr/bin/cpp 
Checking for program ar                  : /usr/bin/ar 
Checking for program ranlib              : /usr/bin/ranlib 
Checking for g++                         : ok  
Checking for node path                   : not found 
Checking for node prefix                 : ok /usr/local 
Checking for library z                   : npm info preinstall sax@0.5.1
npm info build /opt/Hilary/node_modules/passport-saml/node_modules/xml2js/node_modules/sax
npm info linkStuff sax@0.5.1
npm info install sax@0.5.1
npm info postinstall sax@0.5.1
npm info build /opt/Hilary/node_modules/passport-saml/node_modules/xml2js
npm info linkStuff xml2js@0.2.0
npm info install xml2js@0.2.0
npm info postinstall xml2js@0.2.0
not found 
/opt/Hilary/node_modules/passport-saml/node_modules/zlib/wscript:18: error: Missing zlib
npm info zlib@1.0.5 Failed to exec install script
npm info /opt/Hilary/node_modules/passport-saml/node_modules/zlib unbuild
npm info preuninstall zlib@1.0.5
npm info uninstall zlib@1.0.5
npm info postuninstall zlib@1.0.5
npm info /opt/Hilary/node_modules/passport-saml unbuild
npm info preuninstall passport-saml@0.0.4
npm info uninstall passport-saml@0.0.4
npm info postuninstall passport-saml@0.0.4
npm ERR! zlib@1.0.5 install: `node-waf clean ; node-waf configure build`
npm ERR! `sh "-c" "node-waf clean ; node-waf configure build"` failed with 1
npm ERR! 
npm ERR! Failed at the zlib@1.0.5 install script.
npm ERR! This is most likely a problem with the zlib package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-waf clean ; node-waf configure build
npm ERR! You can get their info via:
npm ERR!     npm owner ls zlib
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 11.4.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "-d"
npm ERR! cwd /opt/Hilary
npm ERR! node -v v0.8.8
npm ERR! npm -v 1.1.59
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /opt/Hilary/npm-debug.log
npm ERR! not ok code 0
```
