### PR TITLE
Update saml.js

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -155,7 +155,7 @@ SAML.prototype.certToPEM = function (cert) {
 SAML.prototype.validateSignature = function (xml, cert) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath.SelectNodes(doc, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xmlCrypto.xpath(doc, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {


### PR DESCRIPTION
SelectNodes isn't defined anymore but using the xpath reference directly works. See https://github.com/MSOpenTech/passport-azure-ad/commit/75314e63ba6bd5c110f6753a81d90431fe2c1a56
