### PR TITLE
Update package.json to fix xml-crypto version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "passport": "0.1.x",
     "xml2js": "0.2.0",
-    "xml-crypto": "0.0.x",
+    "xml-crypto": "0.0.13",
     "xmldom": "0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
xml-crypto changed xpath implementation on version 0.0.14 and it is throwing method not found:

TypeError: Object function SelectNodes(doc, xpath)
{
  var parser = new XPathParser();
  var xpath = parser.parse(xpath);
  var context = new XPathContext();
  if(doc.documentElement){
    context.expressionContextNode = doc.documentElement;
  } else {
    context.expressionContextNode = doc;
  }
  var res = xpath.evaluate(context)

  return res.toArray();
} has no method 'SelectNodes'
    at SAML.validateSignature (/passport-saml/lib/passport-saml/saml.js:158:35)
