### PR TITLE
Support NameID without Format attribute

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -420,9 +420,9 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
     if (subject) {
       var nameID = subject[0].NameID;
       if (nameID) {
-          profile.nameID = nameID[0]._;
+        profile.nameID = nameID[0]._ || nameID[0];
 
-        if (nameID[0].$.Format) {
+        if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;
         }
       }
@@ -582,8 +582,9 @@ function processValidlySignedPostRequest(self, doc, callback) {
 
       var nameID = request.NameID;
       if (nameID) {
-        profile.nameID = nameID[0]._;
-        if (nameID[0].$.Format) {
+        profile.nameID = nameID[0]._ || nameID[0];
+
+        if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;
         }
       } else {


### PR DESCRIPTION
`Format` is an optional attribute of the `NameID` element, so allow it to be absent.
