### PR TITLE
Support for node id attribute variations (e.g. "ID", "Id", etc.)

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -282,11 +282,14 @@ SAML.prototype.validateSignature = function (fullXml, currentNode, cert) {
   var refUri = sig.references[0].uri;
   var refId = (refUri[0] === '#') ? refUri.substring(1) : refUri;
   // If we can't find the reference at the top level, reject
-  if (currentNode.getAttribute('ID') != refId)
+  var idAttribute = sig.idAttributes.filter(function (attribute) {
+    return currentNode.getAttribute(attribute) == refId;
+  })[0];
+  if (idAttribute === undefined)
     return false;
   // If we find any extra referenced nodes, reject.  (xml-crypto only verifies one digest, so
   //   multiple candidate references is bad news)
-  var totalReferencedNodes = xpath(currentNode.ownerDocument, "//*[@ID='" + refId + "']");
+  var totalReferencedNodes = xpath(currentNode.ownerDocument, "//*[@" + idAttribute + "='" + refId + "']");
   if (totalReferencedNodes.length > 1)
     return false;
   return sig.checkSignature(fullXml);


### PR DESCRIPTION
Resolves #47.
