### PR TITLE
Improve error handling from Express

### DIFF
--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -58,7 +58,7 @@ Strategy.prototype.authenticate = function (req, options) {
 
   function redirectIfSuccess(err, url) {
     if (err) {
-      self.fail();
+      self.error();
     } else {
       self.redirect(url);
     }


### PR DESCRIPTION
A small change that I think improves the error handling... the scenario I have is the following:
- an error occurs during the logic to generate the request to the Identity provider (error the implementation of a custom `cacheProvider`)
- with the existing code, this is essentially a silent error, and Passport-SAML redirects to the `failureRedirect` option, but there is no opportunity for any higher level application code to see the error, log it, etc...

Changing this line to call `error()` seems to do the right thing, which let's an Express error handling middleware catch the error if configured globally for example after all routes.  Example:

```
app.use(function(err, req, res, next) {

    // log and handle err, which can come from Passport-SAML catastrophic error...
});
```

It seems like calling `error()` is the right thing according to Passport comments:

```
      /**
       * Internal error while performing authentication.
       *
       * Strategies should call this function when an internal error occurs
       * during the process of performing authentication; for example, if the
       * user directory is not available.
       *
       * @param {Error} err
       * @api public
       */
```
