### PR TITLE
feat: allow the auth context to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Config parameter details:
 * `requestIdExpirationPeriodMs`: Defines the expiration time when a Request ID generated for a SAML request will not be valid if seen in a SAML response in the `InResponseTo` field.  Default is 8 hours.
 * `cacheProvider`: Defines the implementation for a cache provider used to store request Ids generated in SAML requests as part of `InResponseTo` validation.  Default is a built-in in-memory cache provider.  For details see the 'Cache Provider' section.
 * `attributeConsumingServiceIndex`: optional `AttributeConsumingServiceIndex` attribute to add to AuthnRequest to instruct the IDP which attribute set to attach to the response ([link](http://blog.aniljohn.com/2014/01/data-minimization-front-channel-saml-attribute-requests.html))
+* `disableRequestedAuthnContext`: if truthy, do not request a specific auth context
+* `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`)
 
 ### Provide the authentication callback
 
@@ -115,6 +117,7 @@ Here is a configuration that has been proven to work with ADFS:
     issuer: 'https://your-app.example.net/login/callback',
     callbackUrl: 'https://your-app.example.net/login/callback',
     cert: 'MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W==',
+    authnContext: 'http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/windows',
     identifierFormat: null
   }
 ```

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -34,6 +34,10 @@ SAML.prototype.initialize = function (options) {
     options.identifierFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
   }
 
+  if (options.authnContext === undefined) {
+    options.authnContext = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport";
+  }
+
   if (!options.acceptedClockSkewMs) {
     // default to no skew
     options.acceptedClockSkewMs = 0;
@@ -129,7 +133,7 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
         '@Comparison': 'exact',
         'saml:AuthnContextClassRef': {
           '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-          '#text': 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+          '#text': self.options.authnContext
         }
       };
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -258,6 +258,40 @@ describe( 'passport-saml /', function() {
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'alternateIdentifier',
                      AllowCreate: 'true' } } ] } }
+      },
+      { name: "Config with AuthnContext",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          passive: true,
+          attributeConsumingServiceIndex: 123,
+          authnContext: 'myAuthnContext'
+        },
+        result: { 
+          'samlp:AuthnRequest': 
+           { '$': 
+              { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                Version: '2.0',
+                ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                AttributeConsumingServiceIndex: '123',
+                Destination: 'https://wwwexampleIdp.com/saml',
+                IsPassive: 'true' },
+             'saml:Issuer': 
+              [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+             'samlp:NameIDPolicy': 
+              [ { '$': 
+                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                     Format: 'alternateIdentifier',
+                     AllowCreate: 'true' } } ],
+             'samlp:RequestedAuthnContext': 
+              [ { '$': 
+                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                     Comparison: 'exact' },
+                  'saml:AuthnContextClassRef': 
+                   [ { _: 'myAuthnContext',
+                       '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       }
     ];
 


### PR DESCRIPTION
This is useful because ADFS does not recognize the default value in this plugin (`urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`) and wants `http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/windows` in there instead.

I believe you can also set `disableRequestedAuthnContext` to `true` to get this to work. Since this parameter was not documented I also added an entry for it.
