### PR TITLE
add `passReqToCallback` option to be compatible with other strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Config parameter details:
 * `attributeConsumingServiceIndex`: optional `AttributeConsumingServiceIndex` attribute to add to AuthnRequest to instruct the IDP which attribute set to attach to the response ([link](http://blog.aniljohn.com/2014/01/data-minimization-front-channel-saml-attribute-requests.html))
 * `disableRequestedAuthnContext`: if truthy, do not request a specific auth context
 * `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`)
+* `passReqToCallback`: if truthy, `req` will be passed as the first argument to the verify callback (default: `false`)
 
 ### Provide the authentication callback
 

--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -18,6 +18,7 @@ function Strategy (options, verify) {
 
   this._verify = verify;
   this._saml = new saml.SAML(options);
+  this._passReqToCallback = !!options.passReqToCallback;
 }
 
 util.inherits(Strategy, passport.Strategy);
@@ -53,7 +54,11 @@ Strategy.prototype.authenticate = function (req, options) {
         self.success(user, info);
       };
 
-      self._verify(profile, verified);
+      if (self._passReqToCallback) {
+        self._verify(req, profile, verified);
+      } else {
+        self._verify(profile, verified);
+      }
   }
 
   function redirectIfSuccess(err, url) {


### PR DESCRIPTION
if `passReqToCallback` options is truthy, `req` will be passed as the first argument to the verify callback (default: `false`)

see: [Association in Verify Callback](http://passportjs.org/guide/authorize/)

This PR makes passport-saml compatible with

 - [passport-local](https://github.com/jaredhanson/passport-local)
 - [passport-openid](https://github.com/jaredhanson/passport-openid)
 - [passport-oauth1](https://github.com/jaredhanson/passport-oauth1)
 - [passport-oauth2](https://github.com/jaredhanson/passport-oauth2)

and many others based on them (like [passport-twitter](https://github.com/jaredhanson/passport-twitter) or [passport-facebook](https://github.com/jaredhanson/passport-facebook)).
