### PR TITLE
Use logoutUrl for generateLogoutRequest

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -55,6 +55,11 @@ SAML.prototype.initialize = function (options) {
       options.cacheProvider = new InMemoryCacheProvider(
           {keyExpirationPeriodMs: options.requestIdExpirationPeriodMs });
   }
+  
+  if (!options.logoutUrl) {
+    // Default to Entry Point
+    options.logoutUrl = options.entryPoint || '';
+  }
 
   return options;
 };

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -161,7 +161,7 @@ SAML.prototype.generateLogoutRequest = function (req) {
       '@ID': id,
       '@Version': '2.0',
       '@IssueInstant': instant,
-      '@Destination': this.options.entryPoint,
+      '@Destination': this.options.logoutUrl,
       'saml:Issuer' : {
         '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
         '#text': this.options.issuer


### PR DESCRIPTION
# Description
Currently, when generating a LogoutRequest, `options.entryPoint` is used as the `@Destination` property. This will not validate from an IdP, resulting in the user **not** logging out. Setting `@Destination` to `options.logoutUrl` fixes this issue, allowing the user to log out of the IdP and be correctly redirected back.