### PR TITLE
Pass 'RelayState' from query string into req body

### DIFF
--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -28,6 +28,10 @@ Strategy.prototype.authenticate = function (req, options) {
 
   options.samlFallback = options.samlFallback || 'login-request';
 
+  if ( req.query.RelayState ) {
+      req.body.RelayState = req.query.RelayState ;
+  }
+  
   function validateCallback(err, profile, loggedOut) {
       if (err) {
         return self.error(err);


### PR DESCRIPTION
I didn't find an easy way to "automatically" add a dynamic RelayState to the SAML AuthN request, so I made this change to the passport-saml strategy. If you put a RelayState query parameter on the request that calls the passport-saml middleware, the req.body.RelayState is set to this value. This allows you to, for example, put the actual request URL (encoded appropriately) into the RelayState value (which used to be a common thing to do in SAML implementations). I expect you can probably implement a passport cache provider for this, but this seemed simpler and is effective enough (for now). 