### PR TITLE
Add Destination attribute to LogoutResponse

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -197,6 +197,7 @@ SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
       '@ID': id,
       '@Version': '2.0',
       '@IssueInstant': instant,
+      '@Destination': this.options.logoutUrl,
       '@InResponseTo': logoutRequest.ID,
       'saml:Issuer' : {
         '#text': this.options.issuer

--- a/test/tests.js
+++ b/test/tests.js
@@ -461,11 +461,12 @@ describe( 'passport-saml /', function() {
               //ID: '_d11b3c5e085b2417f4aa',
               Version: '2.0',
               //IssueInstant: '2014-05-29T01:11:32Z',
+              Destination: 'foo',
               InResponseTo: 'quux' },
            'saml:Issuer': [ 'onelogin_saml' ],
            'samlp:Status': [ { 'samlp:StatusCode': [ { '$': { Value: 'urn:oasis:names:tc:SAML:2.0:status:Success' } } ] } ] } };
 
-      var samlObj = new SAML( {} );
+      var samlObj = new SAML( { entryPoint: "foo" } );
       var logoutRequest = samlObj.generateLogoutResponse({}, { ID: "quux" });
       parseString( logoutRequest, function( err, doc ) {
         delete doc['samlp:LogoutResponse']['$']["ID"];


### PR DESCRIPTION
Add Destination attribute to the LogoutResponse to be compliant with the spec.

See section 3.4.5.2 and 3.5.5.2 of http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
> If the message is signed, the Destination XML attribute in the root SAML element of the protocol message MUST contain the URL to which the sender has instructed the user agent to deliver the message. The recipient MUST then verify that the value matches the location at which the message has been received.

Without the Destination attribute, PingFederate (at least in 6.10) will reject the LogoutResponse.