### PR TITLE
Fix issue where query strings in entry points mess up entryPoint URLs

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -3,6 +3,7 @@ var xml2js = require('xml2js');
 var xmlCrypto = require('xml-crypto');
 var crypto = require('crypto');
 var xmldom = require('xmldom');
+var url = require('url');
 var querystring = require('querystring');
 var xmlbuilder = require('xmlbuilder');
 var xmlenc = require('xml-encryption');
@@ -226,11 +227,11 @@ SAML.prototype.requestToUrl = function (request, response, operation, additional
     }
 
     var base64 = buffer.toString('base64');
-    var target = self.options.entryPoint + '?';
+    var target = url.parse(self.options.entryPoint, true);
 
     if (operation === 'logout') {
       if (self.options.logoutUrl) {
-        target = self.options.logoutUrl + '?';
+        target = url.parse(self.options.logoutUrl, true);
       }
     } else if (operation !== 'authorize') {
         return callback(new Error("Unknown operation: "+operation));
@@ -249,9 +250,15 @@ SAML.prototype.requestToUrl = function (request, response, operation, additional
       samlMessage.SigAlg = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
       samlMessage.Signature = self.signRequest(querystring.stringify(samlMessage));
     }
-    target += querystring.stringify(samlMessage);
+    Object.keys(samlMessage).forEach(function(k) {
+      target.query[k] = samlMessage[k];
+    });
 
-    callback(null, target);
+    // Delete 'search' to for pulling query string from 'query'
+    // https://nodejs.org/api/url.html#url_url_format_urlobj
+    delete target.search;
+
+    callback(null, url.format(target));
   }
 };
 

--- a/test/samlTests.js
+++ b/test/samlTests.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var SAML = require('../lib/passport-saml/saml.js').SAML;
+var should = require('should');
+var url = require('url');
+
+describe('SAML.js', function() {
+  describe('getAuthorizeUrl', function() {
+    var saml, req;
+    beforeEach(function() {
+      saml = new SAML({
+        entryPoint: 'https://exampleidp.com/path?key=value'
+      });
+      req = {
+        protocol: 'https',
+        headers: {
+          host: 'examplesp.com'
+        }
+      }
+    });
+    it('calls callback with right host', function(done) {
+      saml.getAuthorizeUrl(req, function(err, target) {
+        url.parse(target).host.should.equal('exampleidp.com');
+        done();
+      });
+    });
+    it('calls callback with right protocol', function(done) {
+      saml.getAuthorizeUrl(req, function(err, target) {
+        url.parse(target).protocol.should.equal('https:');
+        done();
+      });
+    })
+    it('calls callback with right path', function(done) {
+      saml.getAuthorizeUrl(req, function(err, target) {
+        url.parse(target).pathname.should.equal('/path');
+        done();
+      });
+    })
+    it('calls callback with original query string', function(done) {
+      saml.getAuthorizeUrl(req, function(err, target) {
+        url.parse(target, true).query['key'].should.equal('value');
+        done();
+      });
+    })
+    // NOTE: This test only tests existence of the assertion, not the correctness
+    it('calls callback with saml request object', function(done) {
+      saml.getAuthorizeUrl(req, function(err, target) {
+        url.parse(target, true).query.should.have.property('SAMLRequest');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Noticed an issue where you a query string in an entrypoint will not be handled correctly. For example:

```
{
   entryPoint: 'https://exampleidp.com/path?key=value'
}
```
would end up causing a URL such as `https://exampleidp.com/path?key=value?SAMLRequest=...`

The existing tests were a little complicated for me to figure out where to throw some tests to validate behavior. I decided to write some simple tests separately to expose the issue and validate this fixes it.

Let me know if there is anything else you would like to see.