### PR TITLE
SessionIndex / WSO2 logout

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -186,6 +186,36 @@ SAML.prototype.generateLogoutRequest = function (req) {
   return xmlbuilder.create(request).end();
 };
 
+SAML.prototype.generateSaml2pLogoutRequest = function (req) {
+  var id = "_" + this.generateUniqueID();
+  var instant = this.generateInstant();
+
+  var request = {
+    'saml2p:LogoutRequest' : {
+      '@xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol',
+      '@Reason': 'urn:oasis:names:tc:SAML:2.0:logout:user',
+      '@ID': id,
+      '@Version': '2.0',
+      '@IssueInstant': instant,
+      '@Destination': this.options.logoutUrl,
+      'saml2:Issuer' : {
+        '@xmlns:saml2': 'urn:oasis:names:tc:SAML:2.0:assertion',
+        '#text': this.options.issuer
+      },
+      'saml2:NameID' : {
+        '@xmlns:saml2': 'urn:oasis:names:tc:SAML:2.0:assertion',
+        '@Format': req.user.nameIDFormat,
+        '#text': req.user.nameID
+      },
+      'saml2p:SessionIndex' : {
+        '#text': req.user.sessionIndex
+      }
+    }
+  };
+
+  return xmlbuilder.create(request).end();
+}
+
 SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
@@ -294,8 +324,10 @@ SAML.prototype.getAuthorizeUrl = function (req, callback) {
 };
 
 SAML.prototype.getLogoutUrl = function(req, callback) {
-  var request = this.generateLogoutRequest(req);
+  //var request = this.generateLogoutRequest(req);
+  var request = this.generateSaml2pLogoutRequest(req);
   var operation = 'logout';
+  console.log(request);
   this.requestToUrl(request, null, operation, this.getAdditionalParams(req, operation), callback);
 };
 
@@ -525,6 +557,13 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
     var issuer = assertion.Issuer;
     if (issuer) {
       profile.issuer = issuer[0];
+    }
+
+    var authnStatement = assertion.AuthnStatement;
+    if (authnStatement) {
+      if (authnStatement[0].$ && authnStatement[0].$.SessionIndex) {
+        profile.sessionIndex = authnStatement[0].$.SessionIndex;
+      }
     }
 
     var subject = assertion.Subject;

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -183,38 +183,15 @@ SAML.prototype.generateLogoutRequest = function (req) {
     }
   };
 
+  if (req.user.sessionIndex) {
+    request['samlp:LogoutRequest']['saml2p:SessionIndex'] = {
+      '@xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol',
+      '#text': req.user.sessionIndex
+    };
+  }
+
   return xmlbuilder.create(request).end();
 };
-
-SAML.prototype.generateSaml2pLogoutRequest = function (req) {
-  var id = "_" + this.generateUniqueID();
-  var instant = this.generateInstant();
-
-  var request = {
-    'saml2p:LogoutRequest' : {
-      '@xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      '@Reason': 'urn:oasis:names:tc:SAML:2.0:logout:user',
-      '@ID': id,
-      '@Version': '2.0',
-      '@IssueInstant': instant,
-      '@Destination': this.options.logoutUrl,
-      'saml2:Issuer' : {
-        '@xmlns:saml2': 'urn:oasis:names:tc:SAML:2.0:assertion',
-        '#text': this.options.issuer
-      },
-      'saml2:NameID' : {
-        '@xmlns:saml2': 'urn:oasis:names:tc:SAML:2.0:assertion',
-        '@Format': req.user.nameIDFormat,
-        '#text': req.user.nameID
-      },
-      'saml2p:SessionIndex' : {
-        '#text': req.user.sessionIndex
-      }
-    }
-  };
-
-  return xmlbuilder.create(request).end();
-}
 
 SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
   var id = "_" + this.generateUniqueID();
@@ -324,10 +301,8 @@ SAML.prototype.getAuthorizeUrl = function (req, callback) {
 };
 
 SAML.prototype.getLogoutUrl = function(req, callback) {
-  //var request = this.generateLogoutRequest(req);
-  var request = this.generateSaml2pLogoutRequest(req);
+  var request = this.generateLogoutRequest(req);
   var operation = 'logout';
-  console.log(request);
   this.requestToUrl(request, null, operation, this.getAdditionalParams(req, operation), callback);
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -476,6 +476,40 @@ describe( 'passport-saml /', function() {
       });
     });
 
+    it( 'generateLogoutRequest', function( done ) {
+      var expectedRequest = { 
+        'samlp:LogoutRequest': 
+         { '$': 
+            { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+              'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
+              //ID: '_85ba0a112df1ffb57805',
+              Version: '2.0',
+              //IssueInstant: '2014-05-29T03:32:23Z',
+              Destination: 'foo' },
+           'saml:Issuer': 
+            [ { _: 'onelogin_saml',
+                '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+           'saml:NameID': [ { _: 'bar', '$': { Format: 'foo' } } ],
+           'saml2p:SessionIndex': 
+           [ { _: 'session-id', 
+               '$': { 'xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol' } } ] } };
+
+      var samlObj = new SAML( { entryPoint: "foo" } );
+      var logoutRequest = samlObj.generateLogoutRequest({
+        user: {
+          nameIDFormat: 'foo',
+          nameID: 'bar',
+          sessionIndex: 'session-id'
+        }
+      });
+      parseString( logoutRequest, function( err, doc ) {
+        delete doc['samlp:LogoutRequest']['$']["ID"];
+        delete doc['samlp:LogoutRequest']['$']["IssueInstant"];
+        doc.should.eql( expectedRequest );
+        done();
+      });
+    });
+
     it( 'generateServiceProviderMetadata', function( done ) {
       var samlConfig = {
         issuer: 'http://example.serviceprovider.com',


### PR DESCRIPTION
This PR adds `sessionIndex` property to returned profile if one is defined in `AuthnStatement`. In addition it adds `saml2p:SessionIndex` element to the generated logout request if `req.user.sessionIndex` exists.

Related to #81. Tested with WSO2 5.0.0 with following logout URI handler:

```javascript
app.get('/logout', function(req, res) {
  if (req.user == null) {
    return res.redirect('/');
  }
  return samlStrategy.logout(req, function(err, uri) {
    return res.redirect(uri);
  });
});
```