### PR TITLE
Specify SingleLogoutService callback url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Config parameter details:
 * Logout
  * `logoutUrl`: base address to call with logout requests (default: `entryPoint`)
  * `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
+ * `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
 
 ### Provide the authentication callback
 

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -784,18 +784,34 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
       '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
       '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
       '@entityID': this.options.issuer,
+      '@ID': this.options.issuer.replace(/\W/g, '_'),
       'SPSSODescriptor' : {
         '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
-        'KeyDescriptor' : keyDescriptor,
-        'NameIDFormat' : this.options.identifierFormat,
-        'AssertionConsumerService' : {
-          '@index': '1',
-          '@isDefault': 'true',
-          '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-          '@Location': this.options.callbackUrl
-        }
-      },
+        'KeyDescriptor' : keyDescriptor
+      }
     }
+  };
+
+  if (this.options.logoutCallbackUrl) {
+    metadata.EntityDescriptor.SPSSODescriptor['#list'] = [{
+      'SingleLogoutService': {
+        '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        '@Location': this.options.logoutCallbackUrl
+      },
+    }, {
+      'SingleLogoutService': {
+        '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        '@Location': this.options.logoutCallbackUrl
+      }
+    }];
+  }
+
+  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
+  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
+    '@index': '1',
+    '@isDefault': 'true',
+    '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+    '@Location': this.options.callbackUrl
   };
 
   return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor>
       <ds:KeyInfo>

--- a/test/tests.js
+++ b/test/tests.js
@@ -532,6 +532,23 @@ describe( 'passport-saml /', function() {
       done();
     });
 
+    it( 'generateServiceProviderMetadata contains logout callback url', function( done ) {
+      var samlConfig = {
+        issuer: 'http://example.serviceprovider.com',
+        callbackUrl: 'http://example.serviceprovider.com/saml/callback',
+        identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+        decryptionPvk: fs.readFileSync(__dirname + '/static/testshib encryption pvk.pem'),
+        logoutCallbackUrl: 'http://example.serviceprovider.com/logout'
+      };
+
+      var samlObj = new SAML( samlConfig );
+      var decryptionCert = fs.readFileSync(__dirname + '/static/testshib encryption cert.pem', 'utf-8');
+      var metadata = samlObj.generateServiceProviderMetadata( decryptionCert );
+      metadata.should.containEql('SingleLogoutService');
+      metadata.should.containEql(samlConfig.logoutCallbackUrl);
+      done();
+    });
+
     it('#certToPEM should generate valid certificate', function(done){
       var samlConfig = {
         entryPoint: 'https://app.onelogin.com/trust/saml2/http-post/sso/371755',


### PR DESCRIPTION
We're using passport-saml in production and it's great (thanks!).  We've got ADFS automatically updating the service provider metadata, but the current implementation doesn't provide a SingleLogoutService callback URL.

I've added this information to the generated metadata and added a test for it too.  We've been happily running this in production against ADFS 3.0 for several weeks without issue.

I found that the order of elements in the metadata file is important, which is why I removed the inline addition of the `NameIDFormat` and `AssertionConsumerService` elements and instead added them after adding the `SingleLogoutService` bindings (if a `logoutCallbackUrl` option is supplied).