### PR TITLE
skip KeyDescriptor if decryptionPvk is not provided

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -746,7 +746,7 @@ function processValidlySignedPostRequest(self, doc, callback) {
 }
 
 SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
-  var keyDescriptor = null;
+  var keyDescriptor;
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
       throw new Error(
@@ -797,6 +797,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
       },
     }
   };
+
+  if (!keyDescriptor) {
+    delete metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor;
+  }
 
   return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
 };

--- a/test/static/expected metadata without key.xml
+++ b/test/static/expected metadata without key.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com">
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+  </SPSSODescriptor>
+</EntityDescriptor>


### PR DESCRIPTION
According to [SAML:2.0:metadata](http://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd):

```xml
...
<element name="KeyDescriptor" type="md:KeyDescriptorType"/>
<complexType name="KeyDescriptorType">
<sequence>
<element ref="ds:KeyInfo"/>
...
```

if KeyDescriptor exists, then it must have a KeyInfo element.

The change is to delete[A] the `metadata` KeyDescriptor property if `decryptionPvk` is not supplied.

[A]: From oozcitak/xmlbuilder-js@9540ea487f954063df116c9a91f2914db31edcd6, null values will be preserved.