### PR TITLE
Fixed an obscure bug in which certificates may not be found.

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -344,7 +344,7 @@ SAML.prototype.validateSignature = function (fullXml, currentNode, cert) {
   //   than that, reject.
   if (signatures.length != 1)
     return false;
-  var signature = signatures[0].toString();
+  var signature = signatures[0];
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "passport": "0.2.x",
     "q": "1.1.x",
     "xml2js": "0.4.x",
-    "xml-crypto": "0.3.x",
+    "xml-crypto": "0.6.x",
     "xmldom": "0.1.x",
     "xmlbuilder": "2.5.x",
     "xml-encryption": "~0.7"


### PR DESCRIPTION
I did not write up a test case, but I did have to change this in my own implementation,
and it fixed the bug. If you'd like, I will attempt to write an actual test case.

This also more closely mimics the tests in xml-crypt, as [shown here](https://github.com/yaronn/xml-crypto/blob/master/test/saml-response-test.js#L8).


Not sure if anyone else has run into this issue, but I did in a separate project.
The issue is that when the signature node has been serialized to a String,
it loses the context of where it is in the XML tree. When deserialized, it
only knows about itself. Later in the code, in valdiateSignatureValue of xml-crypto,
this is called:

`var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")`

However, if the signature node has been serialized and deserialized, it
incorrectly reports it only has 1 child (itself), as opposed to the correct number.
This causes the certificate data to not be found, and the validation to fail.

All tests still pass with this change. Update to xml-crypto required.