### PR TITLE
Allow multiple AuthnContextClassRef to be configured

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -128,13 +128,22 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
     }
 
     if (!self.options.disableRequestedAuthnContext) {
+      var contextElements = [];
+      var contexts = self.options.authnContext.split(';');
+
+      for(var ci=0, cl = contexts.length; ci < cl; ci++) {
+        contextElements.push({
+          'saml:AuthnContextClassRef': {
+            '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
+            '#text': contexts[ci]
+          }
+        });
+      }
+
       request['samlp:AuthnRequest']['samlp:RequestedAuthnContext'] = {
         '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
         '@Comparison': 'exact',
-        'saml:AuthnContextClassRef': {
-          '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-          '#text': self.options.authnContext
-        }
+        '#list': contextElements
       };
     }
 


### PR DESCRIPTION
Delimited by a semi-colon `;`

For example: `urn:federation:authentication:windows;urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`