### PR TITLE
xml-crypto: update to 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "passport-strategy": "*",
     "q": "1.1.x",
     "xml2js": "0.4.x",
-    "xml-crypto": "0.6.x",
+    "xml-crypto": "0.8.x",
     "xmldom": "0.1.x",
     "xmlbuilder": "2.5.x",
     "xml-encryption": "~0.7"


### PR DESCRIPTION
The comparison from [0.6.1 to 0.8](https://github.com/yaronn/xml-crypto/compare/f79385dc364135bd16ff44eb13db01e85bb40b76...93891c7173053f73b2739ac222600ee77fc90a41).

As far as I can tell, the only functional changes are:

* yaronn/xml-crypto@da0d09a8b028d5de90a39da8bca24530af399f12 (fixes yaronn/xml-crypto#70)
* yaronn/xml-crypto@d1ddec98eadd78b9f74a0c1aa91223117efe966e
* yaronn/xml-crypto@c6f7aaad7685502101e19f827fa5c001029b4519