### PR TITLE
Document the skipRequestCompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Config parameter details:
  * `disableRequestedAuthnContext`: if truthy, do not request a specific auth context
  * `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`)
  * `forceAuthn`: if set to true, the initial SAML request from the service provider specifies that the IdP should force re-authentication of the user, even if they possess a valid session.
+ * `skipRequestCompression`: if set to true, the SAML request from the service provider won't be compressed.
 * InResponseTo Validation
  * `validateInResponseTo`: if truthy, then InResponseTo will be validated from incoming SAML responses
  * `requestIdExpirationPeriodMs`: Defines the expiration time when a Request ID generated for a SAML request will not be valid if seen in a SAML response in the `InResponseTo` field.  Default is 8 hours.


### PR DESCRIPTION
Some providers don't support SAML compression, or they don't support compressed SAML requests if the assertions is configured to be uncompressed.

So having the skipRequestCompression is nice, and highlighting it in documentation makes it easier for people configuring an SP app through trail and error (not all IDPs gives much in terms of error codes and error messages).

----
I ran into this issue when setting up and app to work with okta. Except for the SAML request compression issue this library works great (granted I had to contact okta support got even figure out that request compression was an issue, but that's their fault for not having error codes, system logs or debug information of any kind).