### PR TITLE
Add NameQualifier and SPNameQualifier to nameID

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -208,6 +208,8 @@ SAML.prototype.generateLogoutRequest = function (req) {
       },
       'saml:NameID' : {
         '@Format': req.user.nameIDFormat,
+        '@NameQualifier': req.user.nameQualifier,
+        '@SPNameQualifier': req.user.spNameQualifier,
         '#text': req.user.nameID
       }
     }
@@ -585,6 +587,8 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
 
         if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;
+          profile.nameQualifier = nameID[0].$.NameQualifier;
+          profile.spNameQualifier = nameID[0].$.SPNameQualifier;
         }
       }
     }

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -208,12 +208,18 @@ SAML.prototype.generateLogoutRequest = function (req) {
       },
       'saml:NameID' : {
         '@Format': req.user.nameIDFormat,
-        '@NameQualifier': req.user.nameQualifier,
-        '@SPNameQualifier': req.user.spNameQualifier,
         '#text': req.user.nameID
       }
     }
   };
+
+  if (typeof(req.user.nameQualifier) !== 'undefined') {
+    request['samlp:LogoutRequest']['saml:NameID']['@NameQualifier'] = req.user.nameQualifier;
+  }
+
+  if (typeof(req.user.spNameQualifier) !== 'undefined') {
+    request['samlp:LogoutRequest']['saml:NameID']['@SPNameQualifier'] = req.user.spNameQualifier;
+  }
 
   if (req.user.sessionIndex) {
     request['samlp:LogoutRequest']['saml2p:SessionIndex'] = {

--- a/test/tests.js
+++ b/test/tests.js
@@ -452,6 +452,40 @@ describe( 'passport-saml /', function() {
       });
     });
 
+    it( 'generateLogoutRequest adds the NameQualifier and SPNameQualifier to the saml request', function( done ) {
+      var expectedRequest = { 
+        'samlp:LogoutRequest': 
+         { '$': 
+            { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+              'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
+              //ID: '_85ba0a112df1ffb57805',
+              Version: '2.0',
+              //IssueInstant: '2014-05-29T03:32:23Z',
+              Destination: 'foo' },
+           'saml:Issuer': 
+            [ { _: 'onelogin_saml',
+                '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+           'saml:NameID': [ { _: 'bar', '$': { Format: 'foo',
+                                               SPNameQualifier: 'Service Provider',
+                                               NameQualifier: 'Identity Provider' } } ] } };
+
+      var samlObj = new SAML( { entryPoint: "foo" } );
+      var logoutRequest = samlObj.generateLogoutRequest({
+        user: {
+          nameIDFormat: 'foo',
+          nameID: 'bar',
+          nameQualifier: 'Identity Provider',
+          spNameQualifier: 'Service Provider'
+        }
+      });
+      parseString( logoutRequest, function( err, doc ) {
+        delete doc['samlp:LogoutRequest']['$']["ID"];
+        delete doc['samlp:LogoutRequest']['$']["IssueInstant"];
+        doc.should.eql( expectedRequest );
+        done();
+      });
+    });
+
     it( 'generateLogoutResponse', function( done ) {
       var expectedResponse =  { 
         'samlp:LogoutResponse': 


### PR DESCRIPTION
The nameID element of the authn response can contain the NameQualifier and
SPNameQualifier attribute optionally. 
[pysaml2](https://github.com/rohe/pysaml2) however, which we use to implement our identity provider, depends on these attributes being present on the logout request. So can we please add this to the logout request?