### PR TITLE
Fix Subject dereference bug

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -610,30 +610,30 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
           profile.spNameQualifier = nameID[0].$.SPNameQualifier;
         }
       }
-    }
 
-    var subjectConfirmation = subject[0].SubjectConfirmation ?
-                              subject[0].SubjectConfirmation[0] : null;
-    var confirmData = subjectConfirmation && subjectConfirmation.SubjectConfirmationData ?
-                      subjectConfirmation.SubjectConfirmationData[0] : null;
-    if (subject[0].SubjectConfirmation && subject[0].SubjectConfirmation.length > 1) {
-      msg = 'Unable to process multiple SubjectConfirmations in SAML assertion';
-      throw new Error(msg);
-    }
+      var subjectConfirmation = subject[0].SubjectConfirmation ?
+                                subject[0].SubjectConfirmation[0] : null;
+      var confirmData = subjectConfirmation && subjectConfirmation.SubjectConfirmationData ?
+                        subjectConfirmation.SubjectConfirmationData[0] : null;
+      if (subject[0].SubjectConfirmation && subject[0].SubjectConfirmation.length > 1) {
+        msg = 'Unable to process multiple SubjectConfirmations in SAML assertion';
+        throw new Error(msg);
+      }
 
-    if (subjectConfirmation) {
-      if (confirmData && confirmData.$) {
-        var subjectNotBefore = confirmData.$.NotBefore;
-        var subjectNotOnOrAfter = confirmData.$.NotOnOrAfter;
+      if (subjectConfirmation) {
+        if (confirmData && confirmData.$) {
+          var subjectNotBefore = confirmData.$.NotBefore;
+          var subjectNotOnOrAfter = confirmData.$.NotOnOrAfter;
 
-        var subjErr = self.checkTimestampsValidityError(
-                        nowMs, subjectNotBefore, subjectNotOnOrAfter);
-        if (subjErr) {
-          throw subjErr;
+          var subjErr = self.checkTimestampsValidityError(
+                          nowMs, subjectNotBefore, subjectNotOnOrAfter);
+          if (subjErr) {
+            throw subjErr;
+          }
         }
       }
     }
-
+    
     // Test to see that if we have a SubjectConfirmation InResponseTo that it matches
     // the 'InResponseTo' attribute set in the Response
     if (self.options.validateInResponseTo) {


### PR DESCRIPTION
The `if (subject)` block is extended to cover all access to `subject`.

We ran into this bug in the code because our SAML provider didn't include Subject at the root of the Assertion -> line 614 throws a 'cannot access 0 of undefined' error.