### PR TITLE
customizable HTTP POST form

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -357,7 +357,7 @@ SAML.prototype.getAuthorizeUrl = function (req, callback) {
   });
 };
 
-SAML.prototype.getAuthorizeForm = function (req, callback) {
+SAML.prototype.getAuthorizeForm = function (req, createCustomForm, callback) {
   var self = this;
 
   // The quoteattr() function is used in a context, where the result will not be evaluated by javascript
@@ -392,29 +392,46 @@ SAML.prototype.getAuthorizeForm = function (req, callback) {
       samlMessage[k] = additionalParameters[k] || '';
     });
 
-    var formInputs = Object.keys(samlMessage).map(function(k) {
-      return '<input type="hidden" name="' + k + '" value="' + quoteattr(samlMessage[k]) + '" />';
-    }).join('\r\n');
+    function toEscapedNameValue(key) {
+      return {
+        name: key,
+        value: quoteattr(samlMessage[key])
+      }
+    }
 
-    callback(null, [
-      '<!DOCTYPE html>',
-      '<html>',
-      '<head>',
-      '<meta charset="utf-8">',
-      '<meta http-equiv="x-ua-compatible" content="ie=edge">',
-      '</head>',
-      '<body onload="document.forms[0].submit()">',
-      '<noscript>',
-      '<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p>',
-      '</noscript>',
-      '<form method="post" action="' + encodeURI(self.options.entryPoint) + '">',
-      formInputs,
-      '<input type="submit" value="Submit" />',
-      '</form>',
-      '<script>document.forms[0].style.display="none";</script>', // Hide the form if JavaScript is enabled
-      '</body>',
-      '</html>'
-    ].join('\r\n'));
+    var escapedNameValues = Object.keys(samlMessage).map(toEscapedNameValue);
+
+    function createDefaultHtmlForm() {
+      var formInputs = escapedNameValues.map(function (input) {
+        return '<input type="hidden" name="' + input.name + '" value="' + input.value + '" />';
+      }).join('\r\n');
+
+      return [
+        '<!DOCTYPE html>',
+        '<html>',
+        '<head>',
+        '<meta charset="utf-8">',
+        '<meta http-equiv="x-ua-compatible" content="ie=edge">',
+        '</head>',
+        '<body onload="document.forms[0].submit()">',
+        '<noscript>',
+        '<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p>',
+        '</noscript>',
+        '<form method="post" action="' + encodeURI(self.options.entryPoint) + '">',
+        formInputs,
+        '<input type="submit" value="Submit" />',
+        '</form>',
+        '<script>document.forms[0].style.display="none";</script>', // Hide the form if JavaScript is enabled
+        '</body>',
+        '</html>'
+      ].join('\r\n');
+    }
+
+    var postBindingForm = createCustomForm
+        ? createCustomForm(escapedNameValues)
+        : createDefaultHtmlForm();
+
+    callback(null, postBindingForm);
   };
 
   self.generateAuthorizeRequest(req, self.options.passive, function(err, request) {

--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -20,6 +20,12 @@ function Strategy (options, verify) {
   this._saml = new saml.SAML(options);
   this._passReqToCallback = !!options.passReqToCallback;
   this._authnRequestBinding = options.authnRequestBinding || 'HTTP-Redirect';
+
+  // option to use a custom POST form for AuthnRequests.
+  // Provide a function which takes an array of { name: , value: } objects.
+  // The values have already been escaped.
+  // Return the form as a string.
+  this._customAuthnRequestForm = options.authnRequestPostForm
 }
 
 util.inherits(Strategy, passport.Strategy);
@@ -78,7 +84,7 @@ Strategy.prototype.authenticate = function (req, options) {
     var requestHandler = {
       'login-request': function() {
         if (self._authnRequestBinding === 'HTTP-POST') {
-          this._saml.getAuthorizeForm(req, function(err, data) {
+          this._saml.getAuthorizeForm(req , options._customAuthnRequestForm, function(err, data) {
             if (err) {
               self.error(err);
             } else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -219,28 +219,28 @@ describe( 'passport-saml /', function() {
       { name: "Empty Config w/ HTTP-POST binding",
         config: { authnRequestBinding: 'HTTP-POST' },
         result: {
-          'samlp:AuthnRequest': 
-           { '$': 
-              { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-                Version: '2.0',
-                ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-                AssertionConsumerServiceURL: 'http://localhost:3033/login',
-                Destination: 'https://wwwexampleIdp.com/saml'},
-             'saml:Issuer': 
-              [ { _: 'onelogin_saml',
+          'samlp:AuthnRequest':
+          { '$':
+          { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+            Version: '2.0',
+            ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+            AssertionConsumerServiceURL: 'http://localhost:3033/login',
+            Destination: 'https://wwwexampleIdp.com/saml'},
+            'saml:Issuer':
+                [ { _: 'onelogin_saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
-                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-                     Format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-                     AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
-                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-                     Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
-                   [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
-                       '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+            'samlp:NameIDPolicy':
+                [ { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+                  AllowCreate: 'true' } } ],
+            'samlp:RequestedAuthnContext':
+                [ { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Comparison: 'exact' },
+                  'saml:AuthnContextClassRef':
+                      [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
       { name: "Config #2",
         config: {


### PR DESCRIPTION
Hi!

We require the HTTP POST form for AuthnRequests to be a custom form. It would be nice to pass the form generator via the options object. The code has been updated to support this.
I didn't find any unit tests testing the current HTTP POST binding, so I didn't add a test for this.

Please have a look,

Thanks!