### PR TITLE
Check for audience

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -759,6 +759,15 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
         throw conErr;
     }
 
+    var audienceRestriction = conditions.AudienceRestriction ? conditions.AudienceRestriction[0] : null;
+
+    if (audienceRestriction.Audience && audienceRestriction.Audience.length > 0) {
+        if (audienceRestriction.Audience.indexOf(self.options.issuer) === -1) {
+            msg = 'Audience does not match ' + self.options.issuer;
+            throw new Error(msg);
+        }
+    }
+
     var attributeStatement = assertion.AttributeStatement;
     if (attributeStatement) {
       var attributes = [].concat.apply([], attributeStatement.filter(function (attr) {


### PR DESCRIPTION
There doesn't seem to be any checks for the audience attribute. This would allow users using the same IDP to authenticate into service provider B if they had a valid token for service provider A (assuming both service providers use the same IDP).

Hopefully this logic is correct, I can add tests if this is verified.
