### PR TITLE
[+] new option to enable custom logout

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -686,14 +686,20 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
         }
       }
 
-      subjectConfirmation = subject[0].SubjectConfirmation ?
-                            subject[0].SubjectConfirmation[0] : null;
+     subjectConfirmation = null;
+
+      if (subject[0].SubjectConfirmation) {
+        for (var i = 0; i < subject[0].SubjectConfirmation.length; i++) {
+          var sc = subject[0].SubjectConfirmation[i];
+          if (sc.$ && sc.$.Method === 'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
+            subjectConfirmation = sc;
+            break;
+          }
+        }
+      }
+
       confirmData = subjectConfirmation && subjectConfirmation.SubjectConfirmationData ?
                     subjectConfirmation.SubjectConfirmationData[0] : null;
-      if (subject[0].SubjectConfirmation && subject[0].SubjectConfirmation.length > 1) {
-        msg = 'Unable to process multiple SubjectConfirmations in SAML assertion';
-        throw new Error(msg);
-      }
 
       if (subjectConfirmation) {
         if (confirmData && confirmData.$) {

--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -35,7 +35,9 @@ Strategy.prototype.authenticate = function (req, options) {
       }
 
       if (loggedOut) {
-        req.logout();
+        if (!options.beforeRedirect)
+          req.logout();
+
         if (profile) {
           req.samlLogoutRequest = profile;
           return self._saml.getLogoutResponseUrl(req, redirectIfSuccess);
@@ -66,7 +68,17 @@ Strategy.prototype.authenticate = function (req, options) {
     if (err) {
       self.error(err);
     } else {
-      self.redirect(url);
+      if (options.beforeRedirect && typeof options.beforeRedirect == 'function') {
+        options.beforeRedirect(req, function(err) {
+          if (err) {
+            self.error(err);
+          }
+          self.redirect(url);
+        });
+      }
+      else {
+        self.redirect(url);
+      }
     }
   }
 


### PR DESCRIPTION
A new `beforeRedirect` option which can be used to implement **custom logout-logic** before _passport-saml_ redirects back to the Identity Provider.
It can be useful when the logout-logic is more complex than a simple `req.logout()`, e.g. database-pools needs to be finished properly.

In case of **Service Provider initiated logout**, it can be used with the following syntax:

```
app.get('/saml-logout',
      passport.authenticate('saml', {
           beforeRedirect: function(req, next) {
                  // custom logout-logic can be here
                  return next();
           },
           samlFallback: 'logout-request',
           failureRedirect: saml-logout/error',
           failureFlash: true
      })
);
```

The custom logout-logic will be executed right before _SAML LogoutRequest_ is sent to the Identity Provider.

In case of **Identity Provider initiated logout**, it can be used with the following syntax:

```
app.post('/saml-logout/callback',
      passport.authenticate('saml', {
           beforeRedirect: function(req, next) {
                  // custom logout-logic can be here
                  return next();
           },
           failureRedirect: saml-logout/error',
           failureFlash: true
      })
);
```

The custom logout-logic will be executed after the validation of the _SAML LogoutRequest_ but right before _SAML LogoutResponse_ is sent to the Identity Provider.
