### PR TITLE
add support for ProviderName attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Config parameter details:
  * `host`: host for callback; will be combined with path and protocol to construct callback url if `callbackUrl` is not specified (default: `localhost`)
  * `entryPoint`: identity provider entrypoint
  * `issuer`: issuer string to supply to identity provider
+ * `providerName`: optional ProviderName string to supply to identity provider (Specifies the human-readable name of the requester for use by the presenter's user agent or the
+identity provider.)
  * `cert`: see 'security and signatures'
  * `privateCert`: see 'security and signatures'
  * `decryptionPvk`: optional private key that will be used to attempt to decrypt any encrypted assertions that are received

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -60,7 +60,7 @@ SAML.prototype.initialize = function (options) {
       options.cacheProvider = new InMemoryCacheProvider(
           {keyExpirationPeriodMs: options.requestIdExpirationPeriodMs });
   }
-  
+
   if (!options.logoutUrl) {
     // Default to Entry Point
     options.logoutUrl = options.entryPoint || '';
@@ -157,7 +157,7 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
         '@IssueInstant': instant,
         '@ProtocolBinding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         '@AssertionConsumerServiceURL': self.getCallbackUrl(req),
-        '@Destination': self.options.entryPoint,        
+        '@Destination': self.options.entryPoint,
         'saml:Issuer' : {
           '@xmlns:saml' : 'urn:oasis:names:tc:SAML:2.0:assertion',
           '#text': self.options.issuer
@@ -193,6 +193,10 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
 
     if (self.options.attributeConsumingServiceIndex) {
       request['samlp:AuthnRequest']['@AttributeConsumingServiceIndex'] = self.options.attributeConsumingServiceIndex;
+    }
+
+    if (self.options.providerName) {
+      request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
     }
 
     callback(null, xmlbuilder.create(request).end());
@@ -371,7 +375,7 @@ SAML.prototype.getAuthorizeForm = function (req, callback) {
       .replace(/"/g, '&quot;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-       // Add other replacements here for HTML only 
+       // Add other replacements here for HTML only
        // Or for XML, only if the named entities are defined in its DTD.
       .replace(/\r\n/g, preserveCR) // Must be before the next replacement.
       .replace(/[\r\n]/g, preserveCR);
@@ -565,8 +569,8 @@ SAML.prototype.validatePostResponse = function (container, callback) {
           if (decryptedAssertions.length != 1)
             throw new Error('Invalid EncryptedAssertion content');
 
-          if (self.options.cert && 
-              !validSignature && 
+          if (self.options.cert &&
+              !validSignature &&
               !self.validateSignature(decryptedXml, decryptedAssertions[0], self.options.cert))
             throw new Error('Invalid signature');
 
@@ -574,7 +578,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
         });
     }
 
-    // If there's no assertion, fall back on xml2js response parsing for the status & 
+    // If there's no assertion, fall back on xml2js response parsing for the status &
     //   LogoutResponse code.
 
     var parserConfig = {
@@ -708,7 +712,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
         }
       }
     }
-    
+
     // Test to see that if we have a SubjectConfirmation InResponseTo that it matches
     // the 'InResponseTo' attribute set in the Response
     if (self.options.validateInResponseTo) {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -396,6 +396,11 @@ SAML.prototype.getAuthorizeForm = function (req, callback) {
       samlMessage[k] = additionalParameters[k] || '';
     });
 
+    if (self.options.privateCert) {
+      // sets .SigAlg and .Signature
+      self.signRequest(samlMessage);
+    }
+
     var formInputs = Object.keys(samlMessage).map(function(k) {
       return '<input type="hidden" name="' + k + '" value="' + quoteattr(samlMessage[k]) + '" />';
     }).join('\r\n');

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -110,10 +110,6 @@ SAML.prototype.signRequest = function (samlMessage) {
   var signer;
   var samlMessageToSign = {};
   switch(this.options.signatureAlgorithm) {
-    case 'sha512':
-      samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
-      signer = crypto.createSign('RSA-SHA512');
-      break;
     case 'sha256':
       samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
       signer = crypto.createSign('RSA-SHA256');

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -219,7 +219,7 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
         sig.keyInfoProvider = {
           getKeyInfo: function (key) {
             var publicCert = public_key = /-----BEGIN CERTIFICATE-----([^-]*)-----END CERTIFICATE-----/g.exec(self.options.publicCert)[1].replace(/[\r\n|\n]/g, '');
-            return "<X509Data><X509Certificate>" + publicCert + "</X509Certificate></X509Data>";
+            return "<ds:X509Data><ds:X509Certificate>" + publicCert + "</ds:X509Certificate></ds:X509Data>";
           }
         };
       }

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -209,7 +209,11 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
     if (self.options.privateCert) {
       var sig = new xmlCrypto.SignedXml();
       sig.signingKey = self.options.privateCert;
-      sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-' + self.options.signatureAlgorithm;
+      if (!self.options.signatureAlgorithm || self.options.signatureAlgorithm === 'sha1') {
+        sig.signatureAlgorithm = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
+      } else {
+        sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-' + self.options.signatureAlgorithm;
+      }
       sig.addReference("//*[local-name(.)='AuthnRequest']", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']);
       if (self.options.publicCert) {
         sig.keyInfoProvider = {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -110,6 +110,10 @@ SAML.prototype.signRequest = function (samlMessage) {
   var signer;
   var samlMessageToSign = {};
   switch(this.options.signatureAlgorithm) {
+    case 'sha512':
+      samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+      signer = crypto.createSign('RSA-SHA512');
+      break;
     case 'sha256':
       samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
       signer = crypto.createSign('RSA-SHA256');

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -209,7 +209,8 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       if (self.options.publicCert) {
         sig.keyInfoProvider = {
           getKeyInfo: function (key) {
-            return "<X509Data><X509Certificate>" + self.options.publicCert + "</X509Certificate></X509Data>";
+            var publicCert = public_key = /-----BEGIN CERTIFICATE-----([^-]*)-----END CERTIFICATE-----/g.exec(self.options.publicCert)[1].replace(/[\r\n|\n]/g, '');
+            return "<X509Data><X509Certificate>" + publicCert + "</X509Certificate></X509Data>";
           }
         };
       }

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -199,27 +199,28 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
     }
     
+    var xml = xmlbuilder.create(request).end();
+    
     if (self.options.privateCert) {
-      var msg = {
-        SAMLRequest: request
-      };
-      self.signRequest(msg);
-
-      request['samlp:AuthnRequest']['ds:Signature'] = {
-        '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
-        'ds:SignedInfo': {
-          'ds:CanonicalizationMethod': {
-            '@Algorithm': 'http://www.w3.org/2001/10/xml-exc-c14n#'
-          },
-          'ds:SignatureMethod': {
-            '@Algorithm': msg.SigAlg
+      var sig = new xmlCrypto.SignedXml();
+      sig.signingKey = self.options.privateCert;
+      sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-' + self.options.signatureAlgorithm;
+      sig.addReference("//*[local-name(.)='AuthnRequest']", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature']);
+      if (self.options.publicCert) {
+        sig.keyInfoProvider = {
+          getKeyInfo: function (key) {
+            return "<X509Data><X509Certificate>" + self.options.publicCert + "</X509Certificate></X509Data>";
           }
-        },
-        'ds:SignatureValue': msg.Signature
-      };
+        };
+      }
+      sig.computeSignature(xml, {
+        prefix: 'ds'
+      });
+      //var signature = sig.getSignatureXml();
+      xml = sig.getSignedXml();
     }
 
-    callback(null, xmlbuilder.create(request).end());
+    callback(null, xml);
   })
   .fail(function(err){
     callback(err);

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -114,6 +114,10 @@ SAML.prototype.signRequest = function (samlMessage) {
       samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
       signer = crypto.createSign('RSA-SHA256');
       break;
+    case 'sha512':
+      samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+      signer = crypto.createSign('RSA-SHA512');
+      break;
     default:
       samlMessage.SigAlg = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
       signer = crypto.createSign('RSA-SHA1');

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -198,6 +198,26 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
     if (self.options.providerName) {
       request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
     }
+    
+    if (self.options.privateCert) {
+      var msg = {
+        SAMLRequest: request
+      };
+      self.signRequest(msg);
+
+      request['samlp:AuthnRequest']['ds:Signature'] = {
+        '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
+        'ds:SignedInfo': {
+          'ds:CanonicalizationMethod': {
+            '@Algorithm': 'http://www.w3.org/2001/10/xml-exc-c14n#'
+          },
+          'ds:SignatureMethod': {
+            '@Algorithm': msg.SigAlg
+          }
+        },
+        'ds:SignatureValue': msg.Signature
+      };
+    }
 
     callback(null, xmlbuilder.create(request).end());
   })
@@ -395,11 +415,6 @@ SAML.prototype.getAuthorizeForm = function (req, callback) {
     Object.keys(additionalParameters).forEach(function(k) {
       samlMessage[k] = additionalParameters[k] || '';
     });
-
-    if (self.options.privateCert) {
-      // sets .SigAlg and .Signature
-      self.signRequest(samlMessage);
-    }
 
     var formInputs = Object.keys(samlMessage).map(function(k) {
       return '<input type="hidden" name="' + k + '" value="' + quoteattr(samlMessage[k]) + '" />';

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -199,13 +199,18 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
     }
     
-    var xml = xmlbuilder.create(request).end();
-    
+    var xmlObj = xmlbuilder.create(request, null, {headless: true});
+    if (self.options.privateCert) {
+      xmlObj.comment('insert-signature-here');
+    }
+
+    var xml = xmlObj.end();
+
     if (self.options.privateCert) {
       var sig = new xmlCrypto.SignedXml();
       sig.signingKey = self.options.privateCert;
       sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-' + self.options.signatureAlgorithm;
-      sig.addReference("//*[local-name(.)='AuthnRequest']", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature']);
+      sig.addReference("//*[local-name(.)='AuthnRequest']", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']);
       if (self.options.publicCert) {
         sig.keyInfoProvider = {
           getKeyInfo: function (key) {
@@ -217,8 +222,8 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       sig.computeSignature(xml, {
         prefix: 'ds'
       });
-      //var signature = sig.getSignatureXml();
-      xml = sig.getSignedXml();
+      var signature = sig.getSignatureXml();
+      xml = xml.replace('<!-- insert-signature-here -->', signature);
     }
 
     callback(null, xml);

--- a/test/samlTests.js
+++ b/test/samlTests.js
@@ -45,7 +45,7 @@ describe('SAML.js', function() {
     // NOTE: This test only tests existence of the assertion, not the correctness
     it('calls callback with saml request object', function(done) {
       saml.getAuthorizeUrl(req, function(err, target) {
-        url.parse(target, true).query.should.have.property('SAMLRequest');
+        should(url.parse(target, true).query).have.property('SAMLRequest');
         done();
       });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -165,7 +165,7 @@ describe( 'passport-saml /', function() {
               should.exist(passedRequest);
               passedRequest.url.should.eql('/login');
               passedRequest.method.should.eql('POST');
-              passedRequest.body.should.eql(check.samlResponse);
+              should(JSON.stringify(passedRequest.body)).eql(JSON.stringify(check.samlResponse));
             } else {
               should.not.exist(passedRequest);
             }
@@ -193,52 +193,52 @@ describe( 'passport-saml /', function() {
       { name: "Empty Config",
         config: {},
         result: {
-          'samlp:AuthnRequest': 
-           { '$': 
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
                 AssertionConsumerServiceURL: 'http://localhost:3033/login',
                 Destination: 'https://wwwexampleIdp.com/saml'},
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'onelogin_saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
                      AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
+             'samlp:RequestedAuthnContext':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
+                  'saml:AuthnContextClassRef':
                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
       { name: "Empty Config w/ HTTP-POST binding",
         config: { authnRequestBinding: 'HTTP-POST' },
         result: {
-          'samlp:AuthnRequest': 
-           { '$': 
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
                 AssertionConsumerServiceURL: 'http://localhost:3033/login',
                 Destination: 'https://wwwexampleIdp.com/saml'},
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'onelogin_saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
                      AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
+             'samlp:RequestedAuthnContext':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
+                  'saml:AuthnContextClassRef':
                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
@@ -250,9 +250,9 @@ describe( 'passport-saml /', function() {
           attributeConsumingServiceIndex: 123,
           forceAuthn: false
         },
-        result: { 
-          'samlp:AuthnRequest': 
-           { '$': 
+        result: {
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
@@ -260,19 +260,19 @@ describe( 'passport-saml /', function() {
                 AttributeConsumingServiceIndex: '123',
                 Destination: 'https://wwwexampleIdp.com/saml',
                 IsPassive: 'true'},
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'http://exampleSp.com/saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'alternateIdentifier',
                      AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
+             'samlp:RequestedAuthnContext':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
+                  'saml:AuthnContextClassRef':
                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
@@ -284,9 +284,9 @@ describe( 'passport-saml /', function() {
           attributeConsumingServiceIndex: 123,
           skipRequestCompression: true
         },
-        result: { 
-          'samlp:AuthnRequest': 
-           { '$': 
+        result: {
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
@@ -294,19 +294,19 @@ describe( 'passport-saml /', function() {
                 AttributeConsumingServiceIndex: '123',
                 Destination: 'https://wwwexampleIdp.com/saml',
                 IsPassive: 'true' },
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'http://exampleSp.com/saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'alternateIdentifier',
                      AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
+             'samlp:RequestedAuthnContext':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
+                  'saml:AuthnContextClassRef':
                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
@@ -320,9 +320,9 @@ describe( 'passport-saml /', function() {
           disableRequestedAuthnContext: true,
           forceAuthn: true
         },
-        result: { 
-          'samlp:AuthnRequest': 
-           { '$': 
+        result: {
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
@@ -331,11 +331,11 @@ describe( 'passport-saml /', function() {
                 Destination: 'https://wwwexampleIdp.com/saml',
                 IsPassive: 'true',
                 ForceAuthn: 'true' },
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'http://exampleSp.com/saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'alternateIdentifier',
                      AllowCreate: 'true' } } ] } }
@@ -348,9 +348,9 @@ describe( 'passport-saml /', function() {
           attributeConsumingServiceIndex: 123,
           authnContext: 'myAuthnContext'
         },
-        result: { 
-          'samlp:AuthnRequest': 
-           { '$': 
+        result: {
+          'samlp:AuthnRequest':
+           { '$':
               { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                 Version: '2.0',
                 ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
@@ -358,19 +358,19 @@ describe( 'passport-saml /', function() {
                 AttributeConsumingServiceIndex: '123',
                 Destination: 'https://wwwexampleIdp.com/saml',
                 IsPassive: 'true'},
-             'saml:Issuer': 
+             'saml:Issuer':
               [ { _: 'http://exampleSp.com/saml',
                   '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
-             'samlp:NameIDPolicy': 
-              [ { '$': 
+             'samlp:NameIDPolicy':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Format: 'alternateIdentifier',
                      AllowCreate: 'true' } } ],
-             'samlp:RequestedAuthnContext': 
-              [ { '$': 
+             'samlp:RequestedAuthnContext':
+              [ { '$':
                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
                      Comparison: 'exact' },
-                  'saml:AuthnContextClassRef': 
+                  'saml:AuthnContextClassRef':
                    [ { _: 'myAuthnContext',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       }
@@ -393,7 +393,7 @@ describe( 'passport-saml /', function() {
           })
         );
 
-        app.get( '/login', 
+        app.get( '/login',
           passport.authenticate( "saml", { samlFallback: 'login-request', session: false } ),
           function(req, res) {
             res.status(200).send("200 OK");
@@ -458,16 +458,16 @@ describe( 'passport-saml /', function() {
 
   describe( 'saml.js / ', function() {
     it( 'generateLogoutRequest', function( done ) {
-      var expectedRequest = { 
-        'samlp:LogoutRequest': 
-         { '$': 
+      var expectedRequest = {
+        'samlp:LogoutRequest':
+         { '$':
             { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
               'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
               //ID: '_85ba0a112df1ffb57805',
               Version: '2.0',
               //IssueInstant: '2014-05-29T03:32:23Z',
               Destination: 'foo' },
-           'saml:Issuer': 
+           'saml:Issuer':
             [ { _: 'onelogin_saml',
                 '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
            'saml:NameID': [ { _: 'bar', '$': { Format: 'foo' } } ] } };
@@ -488,16 +488,16 @@ describe( 'passport-saml /', function() {
     });
 
     it( 'generateLogoutRequest adds the NameQualifier and SPNameQualifier to the saml request', function( done ) {
-      var expectedRequest = { 
-        'samlp:LogoutRequest': 
-         { '$': 
+      var expectedRequest = {
+        'samlp:LogoutRequest':
+         { '$':
             { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
               'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
               //ID: '_85ba0a112df1ffb57805',
               Version: '2.0',
               //IssueInstant: '2014-05-29T03:32:23Z',
               Destination: 'foo' },
-           'saml:Issuer': 
+           'saml:Issuer':
             [ { _: 'onelogin_saml',
                 '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
            'saml:NameID': [ { _: 'bar', '$': { Format: 'foo',
@@ -522,9 +522,9 @@ describe( 'passport-saml /', function() {
     });
 
     it( 'generateLogoutResponse', function( done ) {
-      var expectedResponse =  { 
-        'samlp:LogoutResponse': 
-         { '$': 
+      var expectedResponse =  {
+        'samlp:LogoutResponse':
+         { '$':
             { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
               'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
               //ID: '_d11b3c5e085b2417f4aa',
@@ -546,21 +546,21 @@ describe( 'passport-saml /', function() {
     });
 
     it( 'generateLogoutRequest', function( done ) {
-      var expectedRequest = { 
-        'samlp:LogoutRequest': 
-         { '$': 
+      var expectedRequest = {
+        'samlp:LogoutRequest':
+         { '$':
             { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
               'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
               //ID: '_85ba0a112df1ffb57805',
               Version: '2.0',
               //IssueInstant: '2014-05-29T03:32:23Z',
               Destination: 'foo' },
-           'saml:Issuer': 
+           'saml:Issuer':
             [ { _: 'onelogin_saml',
                 '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
            'saml:NameID': [ { _: 'bar', '$': { Format: 'foo' } } ],
-           'saml2p:SessionIndex': 
-           [ { _: 'session-id', 
+           'saml2p:SessionIndex':
+           [ { _: 'session-id',
                '$': { 'xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol' } } ] } };
 
       var samlObj = new SAML( { entryPoint: "foo" } );
@@ -722,7 +722,7 @@ describe( 'passport-saml /', function() {
       });
 
       it('accept response with an attributeStatement element without attributeValue', function(done) {
-          var container = { 
+          var container = {
               SAMLResponse : fs.readFileSync(
                   __dirname + '/static/response-with-uncomplete-attribute.xml'
               ).toString('base64')


### PR DESCRIPTION
Section in SAML spec:

[saml-core-2.0-os.pdf](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)

ProviderName [Optional]
Specifies the human-readable name of the requester for use by the presenter's user agent or the
identity provider

PS. I just updated the tests to work with the newest should.js version
