### PR TITLE
Use issuer._ if it exists

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -662,7 +662,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
 
     var issuer = assertion.Issuer;
     if (issuer) {
-      profile.issuer = issuer[0];
+      profile.issuer = issuer[0]._ || issuer[0];
     }
 
     var authnStatement = assertion.AuthnStatement;
@@ -859,7 +859,7 @@ function processValidlySignedPostRequest(self, doc, callback) {
       }
       var issuer = request.Issuer;
       if (issuer) {
-        profile.issuer = issuer[0];
+        profile.issuer = issuer[0]._ || issuer[0];
       } else {
         return callback(new Error('Missing SAML issuer'));
       }


### PR DESCRIPTION
For whatever reason, `issuer` was coming through as:
```
{
  _: 'http://theissuer',
  '$': { Format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:entity'
}
```

This PR fixes it, so it will use the value in `_`, similar to what is done elsewhere in `saml.js`