### PR TITLE
Remove unused ejs package from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "body-parser": "1.9.x",
-    "ejs": "1.0.x",
     "express": "4.x",
     "jshint": "*",
     "mocha": "*",


### PR DESCRIPTION
There seems to be zero uses for ejs package, so this PR removes the unused devDependency from package.json.

Fixes #177 by kevinbror.