### PR TITLE
Issue #196: add support for encrypted NameIDs in SLO POST requests

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -838,13 +838,65 @@ SAML.prototype.validatePostRequest = function (container, callback) {
     if (err) {
       return callback(err);
     }
-
+    
+    var validSignature = false;
     // Check if this document has a valid top-level signature
-    if (self.options.cert && !self.validateSignature(xml, dom.documentElement, self.options.cert)) {
-      return callback(new Error('Invalid signature'));
+    if (self.options.cert && self.validateSignature(xml, dom.documentElement, self.options.cert)) {
+      validSignature = true;
     }
-
-    processValidlySignedPostRequest(self, doc, callback);
+    
+    var nameIds = xpath(dom, "/*[local-name()='LogoutRequest']/*[local-name()='NameID']");
+    var encryptedIds = xpath(dom,
+        "/*[local-name()='LogoutRequest']/*[local-name()='EncryptedID']");
+    
+    if (nameIds.length + encryptedIds.length > 1) {
+      callback(new Error('Invalid signature'));
+    }
+    
+    if (nameIds.length === 1) {
+      if (self.options.cert &&
+        !validSignature &&
+        !self.validateSignature(xml, nameIds[0], self.options.cert)) {
+        callback(new Error('Invalid signature'));
+      }
+      return processValidlySignedPostRequest(self, doc, callback);
+    }
+    
+    if (encryptedIds.length === 1) {
+      if (!self.options.decryptionPvk)
+        throw new Error('No decryption key for encrypted SAML response');
+      
+      var encryptedDatas = xpath(encryptedIds[0], "./*[local-name()='EncryptedData']");
+      if (encryptedDatas.length !== 1)
+        throw new Error('Invalid signature');
+      var encryptedDataXml = encryptedDatas[0].toString();
+      
+      var xmlencOptions = {key: self.options.decryptionPvk};
+      return Q.ninvoke(xmlenc, 'decrypt', encryptedDataXml, xmlencOptions)
+        .then(function (decryptedXml) {
+          var decryptedDoc = new xmldom.DOMParser().parseFromString(decryptedXml);
+          var decryptedIds = xpath(decryptedDoc, "/*[local-name()='NameID']");
+          if (decryptedIds.length !== 1)
+            throw new Error('Invalid EncryptedAssertion content');
+          
+          if (self.options.cert &&
+            !validSignature &&
+            !self.validateSignature(decryptedXml, decryptedIds[0], self.options.cert))
+            throw new Error('Invalid signature');
+          
+          parser.parseString(decryptedXml, function (err, nameIdDoc) {
+            if (err) {
+              return callback(err);
+            }
+            doc.LogoutRequest.NameID = [nameIdDoc.NameID];
+            processValidlySignedPostRequest(self, doc, callback);
+          });
+        })
+        .fail(function (err) {
+          callback(err);
+        })
+        .done();
+    }
   });
 };
 

--- a/test/samlTests.js
+++ b/test/samlTests.js
@@ -45,7 +45,7 @@ describe('SAML.js', function() {
     // NOTE: This test only tests existence of the assertion, not the correctness
     it('calls callback with saml request object', function(done) {
       saml.getAuthorizeUrl(req, function(err, target) {
-        url.parse(target, true).query.should.have.property('SAMLRequest');
+        should(url.parse(target, true).query).have.property('SAMLRequest');
         done();
       });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -165,7 +165,8 @@ describe( 'passport-saml /', function() {
               should.exist(passedRequest);
               passedRequest.url.should.eql('/login');
               passedRequest.method.should.eql('POST');
-              passedRequest.body.should.eql(check.samlResponse);
+              should.config.checkProtoEql = false;
+              should(passedRequest.body).eql(check.samlResponse);
             } else {
               should.not.exist(passedRequest);
             }
@@ -183,6 +184,7 @@ describe( 'passport-saml /', function() {
 
     afterEach(function (done) {
       fakeClock.restore();
+      should.config.checkProtoEql = true;
       server.close(done);
     });
   });


### PR DESCRIPTION
PR fixes #196. `validatePostRequest()` updated to support decryption of EncryptedID elements prior to processing assertions (essentially reuses decryption code from `validatePostResponse()`, this could be refactored out instead if desired).