### PR TITLE
Add support for ProviderName attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Config parameter details:
  * `identifierFormat`: if truthy, name identifier format to request from identity provider (default: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`)
  * `acceptedClockSkewMs`: Time in milliseconds of skew that is acceptable between client and server when checking `OnBefore` and `NotOnOrAfter` assertion condition validity timestamps.  Setting to `-1` will disable checking these conditions entirely.  Default is `0`.
  * `attributeConsumingServiceIndex`: optional `AttributeConsumingServiceIndex` attribute to add to AuthnRequest to instruct the IDP which attribute set to attach to the response ([link](http://blog.aniljohn.com/2014/01/data-minimization-front-channel-saml-attribute-requests.html))
+ * `providerName`: optional human-readable name of the requester for use by the presenter's user agent or the identity provider
  * `disableRequestedAuthnContext`: if truthy, do not request a specific auth context
  * `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`)
  * `forceAuthn`: if set to true, the initial SAML request from the service provider specifies that the IdP should force re-authentication of the user, even if they possess a valid session.

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -927,7 +927,7 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
       ]
-    }
+    };
   }
 
   if (this.options.logoutCallbackUrl) {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -199,6 +199,10 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       request['samlp:AuthnRequest']['@AttributeConsumingServiceIndex'] = self.options.attributeConsumingServiceIndex;
     }
 
+    if (self.options.providerName) {
+      request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
+    }
+
     callback(null, xmlbuilder.create(request).end());
   })
   .fail(function(err){

--- a/test/tests.js
+++ b/test/tests.js
@@ -387,6 +387,37 @@ describe( 'passport-saml /', function() {
                   'saml:AuthnContextClassRef':
                    [ { _: 'myAuthnContext',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+      },
+      { name: "Config with ProviderName",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          providerName: 'myProviderName'
+        },
+        result: {
+          'samlp:AuthnRequest':
+           { '$':
+              { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                Version: '2.0',
+                ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                ProviderName: 'myProviderName',
+                AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                Destination: 'https://wwwexampleIdp.com/saml'},
+             'saml:Issuer':
+              [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+             'samlp:NameIDPolicy':
+              [ { '$':
+                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                     Format: 'alternateIdentifier',
+                     AllowCreate: 'true' } } ],
+             'samlp:RequestedAuthnContext':
+              [ { '$':
+                   { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                     Comparison: 'exact' },
+                  'saml:AuthnContextClassRef':
+                   [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                       '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       }
     ];
 


### PR DESCRIPTION
Section in SAML spec:

https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

ProviderName [Optional]
Specifies the human-readable name of the requester for use by the presenter's user agent or the
identity provider.