### PR TITLE
updated xml-encryption dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "passport-strategy": "*",
     "q": "^1.5.0",
     "xml-crypto": "^0.9.0",
-    "xml-encryption": "~0.10",
+    "xml-encryption": "~0.11",
     "xml2js": "0.4.x",
     "xmlbuilder": "^8.2.2",
     "xmldom": "0.1.x"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sinon": "^2.1.0"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
I test in jest and my tests break on:
```
  ● Test suite failed to run

    TypeError: mods[i] is not a function
      
      at Object.module.exports (node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:42:14)
      at defineFunc (node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:48:10)
      at node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:86:14
      at define (node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:15:7)
      at define (node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:55:22)
      at node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:60:1
      at Object.<anonymous> (node_modules/passport-saml/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:88:3)
      at Object.<anonymous> (node_modules/passport-saml/node_modules/xml-encryption/lib/xmlenc.js:6:15)
      at Object.<anonymous> (node_modules/passport-saml/node_modules/xml-encryption/lib/index.js:1:117)
      at Object.<anonymous> (node_modules/passport-saml/lib/passport-saml/saml.js:9:14)
      at Object.<anonymous> (node_modules/passport-saml/lib/passport-saml/strategy.js:3:12)
      at Object.<anonymous> (node_modules/passport-saml/lib/passport-saml/index.js:1:109)
      at Object.<anonymous> (src/model/AuthenticationModel.js:17:20)
      at Object.<anonymous> (src/app.js:170:16)
      at Object.<anonymous> (test/api.spec.js:4:12)
```

This could solve my problem because the newer version of node-forge is in the xml-encryption 0.11.0