### PR TITLE
Use crypto.randomBytes for ID generation

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -94,12 +94,7 @@ SAML.prototype.getCallbackUrl = function (req) {
 };
 
 SAML.prototype.generateUniqueID = function () {
-  var chars = "abcdef0123456789";
-  var uniqueID = "";
-  for (var i = 0; i < 20; i++) {
-    uniqueID += chars.substr(Math.floor((Math.random()*15)), 1);
-  }
-  return uniqueID;
+  return crypto.randomBytes(10).toString('hex');
 };
 
 SAML.prototype.generateInstant = function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -471,6 +471,14 @@ describe( 'passport-saml /', function() {
   });
 
   describe( 'saml.js / ', function() {
+    it( 'generateUniqueID should generate 20 char IDs', function( done ) {
+      var samlObj = new SAML( { entryPoint: "foo" } );
+      for(var i = 0; i < 200; i++){
+          samlObj.generateUniqueID().length.should.eql(20);
+      }
+      done();
+    });
+
     it( 'generateLogoutRequest', function( done ) {
       var expectedRequest = {
         'samlp:LogoutRequest':


### PR DESCRIPTION
Math.random is not cryptographically secure, and IDs generated with it could potentially be predicted. Use crypto.randomBytes instead.

I kept the length of the generated ID the same, but it might also be worth increasing it if that's OK everywhere this function is used, as 20 hex chars is only an 80 bit ID, for which collisions could conceivably occur with a realistic number of stored IDs.