### PR TITLE
SP metadata: distinguish signing and encryption certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,13 @@ app.get('/login',
 );
 ```
 
-### generateServiceProviderMetadata( decryptionCert )
+### generateServiceProviderMetadata( decryptionCert, signingCert )
 
 As a convenience, the strategy object exposes a `generateServiceProviderMetadata` method which will generate a service provider metadata document suitable for supplying to an identity provider.  This method will only work on strategies which are configured with a `callbackUrl` (since the relative path for the callback is not sufficient information to generate a complete metadata document).
 
 The `decryptionCert` argument should be a public certificate matching the `decryptionPvk` and is required if the strategy is configured with a `decryptionPvk`.
 
+The `signingCert` argument should be a public certificate matching the `privateCert` and is required if the strategy is configured with a `privateCert`.
 
 ## Security and signatures
 

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -964,7 +964,7 @@ function processValidlySignedPostRequest(self, doc, callback) {
     }
 }
 
-SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
+SAML.prototype.generateServiceProviderMetadata = function( decryptionCert, signingCert ) {
   var metadata = {
     'EntityDescriptor' : {
       '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
@@ -977,17 +977,19 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
     }
   };
 
+  var KeyDescriptor = [];
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
       throw new Error(
         "Missing decryptionCert while generating metadata for decrypting service provider");
     }
 
-    decryptionCert = decryptionCert.replace( /-+BEGIN CERTIFICATE-+\r?\n?/, '' );
-    decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
+    decryptionCert = decryptionCert.replace( /-+BEGIN (?:CERTIFICATE|PUBLIC KEY)-+\r?\n?/, '' );
+    decryptionCert = decryptionCert.replace( /-+END (?:CERTIFICATE|PUBLIC KEY)-+\r?\n?/, '' );
     decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
 
-    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
+    KeyDescriptor.push({
+      '@use': 'encryption',
       'ds:KeyInfo' : {
         'ds:X509Data' : {
           'ds:X509Certificate': {
@@ -1001,7 +1003,31 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
       ]
-    };
+    });
+  }
+  if (this.options.privateCert) {
+    if (!signingCert) {
+      throw new Error(
+        "Missing signingCert while generating metadata for request signing service provider");
+    }
+
+    signingCert = signingCert.replace( /-+BEGIN (?:CERTIFICATE|PUBLIC KEY)-+\r?\n?/, '' );
+    signingCert = signingCert.replace( /-+END (?:CERTIFICATE|PUBLIC KEY)-+\r?\n?/, '' );
+    signingCert = signingCert.replace( /\r\n/g, '\n' );
+
+    KeyDescriptor.push({
+      '@use': 'signing',
+      'ds:KeyInfo' : {
+        'ds:X509Data' : {
+          'ds:X509Certificate': {
+            '#text': signingCert
+          }
+        }
+      }
+    });
+  }
+  if (KeyDescriptor.length > 0) {
+    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = KeyDescriptor;
   }
 
   if (this.options.logoutCallbackUrl) {


### PR DESCRIPTION
(see #150)
this PR attempts to make SP metadata distinguish between signing and encryption certs (they can be the same, or they can be different, or only of them can be specific).

here's an example with both being specified:
```
    <md:KeyDescriptor use="signing">
      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:X509Data>
          <ds:X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1NbLn2Ao3cyAZ7SyfXif0gfctUML2Vjo9bovTyKF1Z/Ox9qj0lvqxIrKWJ3kPxSy2RXGFQvo7z/odPGMYkYQSQUdFEjVCBKzlT5DKu41NZaqHA9rHPHpLFMzqRkzCVFMPhvoZiVv9MyJ/3O3ZSFgGIjhQi8uxMRruNlwZ1HK5u10ALxEAyBJuhrUnXR6qeiKFYwmJfB5cu/svao5z7CWr2vQ8t9OiTywTz2cyIvzgNMtiqlc6017gy5zDWYyPoVGR6Gb+DyCmCq81VlHgmoDyaVpsPDKFFi4exJ/TiSeFVm/oXLl4Z5AkBdIA8z56T74xqOJjH5+L/ukbY8nZ6NrXQIDAQAB</ds:X509Certificate>
        </ds:X509Data>
      </ds:KeyInfo>
    </md:KeyDescriptor>
    <md:KeyDescriptor use="encryption">
      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:X509Data>
          <ds:X509Certificate>MIIBIjCXBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1NbLn2Ao3cyAZ7SyfXif0gfctUML2Vjo9bovTyKF1Z/Ox9qj0lvqxIrKWJ3kPxSy9RXGFQvo7z/odPGsYkYQSQUdFEjVCBKzlT5DKu41NZaqHA9rHPHpLFMzqRkzCVFMPhvoZiVv9MyJ/3O3ZSFgGIjhQi8uvMRruNlwZ1HK5u10ALxEAyBJuhrUnXR6qeiKFYwmJfB5cu/svao5z7CWr2vQ8t9OiTywTz2cyIvzgNMtiqlc6017gy5zDWYyPoVGR6Gb+DyCmCq81VlHgmoDyaVpsPDKFFi4exJ/TiSeFVm/oXLl4Z5AkBdIA8z56T74xqOJjH5+L/ukbY8nZ6NrXQIDAQAB</ds:X509Certificate>
        </ds:X509Data>
      </ds:KeyInfo>
    </md:KeyDescriptor>
```

(pending tests, and refs to SAML specs, but submitting to start getting feedback on the PR)