### PR TITLE
Adding a method to profile object to get the actual SAML response

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -309,8 +309,7 @@ SAML.prototype.requestToUrl = function(
       return callback(new Error("Unknown operation: " + operation));
     }
 
-    var samlMessage = request
-      ? {
+    var samlMessage = request? {
           SAMLRequest: base64
         }
       : {
@@ -840,12 +839,10 @@ SAML.prototype.processValidlySignedAssertion = function(
           }
         }
 
-        subjectConfirmation = subject[0].SubjectConfirmation
-          ? subject[0].SubjectConfirmation[0]
+        subjectConfirmation = subject[0].SubjectConfirmation? subject[0].SubjectConfirmation[0]
           : null;
         confirmData =
-          subjectConfirmation && subjectConfirmation.SubjectConfirmationData
-            ? subjectConfirmation.SubjectConfirmationData[0]
+          subjectConfirmation && subjectConfirmation.SubjectConfirmationData? subjectConfirmation.SubjectConfirmationData[0]
             : null;
         if (
           subject[0].SubjectConfirmation &&

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1,46 +1,49 @@
-var zlib = require('zlib');
-var xml2js = require('xml2js');
-var xmlCrypto = require('xml-crypto');
-var crypto = require('crypto');
-var xmldom = require('xmldom');
-var url = require('url');
-var querystring = require('querystring');
-var xmlbuilder = require('xmlbuilder');
-var xmlenc = require('xml-encryption');
+var zlib = require("zlib");
+var xml2js = require("xml2js");
+var xmlCrypto = require("xml-crypto");
+var crypto = require("crypto");
+var xmldom = require("xmldom");
+var url = require("url");
+var querystring = require("querystring");
+var xmlbuilder = require("xmlbuilder");
+var xmlenc = require("xml-encryption");
 var xpath = xmlCrypto.xpath;
-var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
-var Q = require('q');
+var InMemoryCacheProvider = require("./inmemory-cache-provider.js")
+  .CacheProvider;
+var Q = require("q");
 
-var SAML = function (options) {
+var SAML = function(options) {
   var self = this;
 
   this.options = this.initialize(options);
   this.cacheProvider = this.options.cacheProvider;
 };
 
-SAML.prototype.initialize = function (options) {
+SAML.prototype.initialize = function(options) {
   if (!options) {
     options = {};
   }
 
   if (!options.path) {
-    options.path = '/saml/consume';
+    options.path = "/saml/consume";
   }
 
   if (!options.host) {
-    options.host = 'localhost';
+    options.host = "localhost";
   }
 
   if (!options.issuer) {
-    options.issuer = 'onelogin_saml';
+    options.issuer = "onelogin_saml";
   }
 
   if (options.identifierFormat === undefined) {
-    options.identifierFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+    options.identifierFormat =
+      "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
   }
 
   if (options.authnContext === undefined) {
-    options.authnContext = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport";
+    options.authnContext =
+      "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport";
   }
 
   if (!options.acceptedClockSkewMs) {
@@ -48,38 +51,39 @@ SAML.prototype.initialize = function (options) {
     options.acceptedClockSkewMs = 0;
   }
 
-  if(!options.validateInResponseTo){
+  if (!options.validateInResponseTo) {
     options.validateInResponseTo = false;
   }
 
-  if(!options.requestIdExpirationPeriodMs){
-    options.requestIdExpirationPeriodMs = 28800000;  // 8 hours
+  if (!options.requestIdExpirationPeriodMs) {
+    options.requestIdExpirationPeriodMs = 28800000; // 8 hours
   }
 
-  if(!options.cacheProvider){
-      options.cacheProvider = new InMemoryCacheProvider(
-          {keyExpirationPeriodMs: options.requestIdExpirationPeriodMs });
+  if (!options.cacheProvider) {
+    options.cacheProvider = new InMemoryCacheProvider({
+      keyExpirationPeriodMs: options.requestIdExpirationPeriodMs
+    });
   }
 
   if (!options.logoutUrl) {
     // Default to Entry Point
-    options.logoutUrl = options.entryPoint || '';
+    options.logoutUrl = options.entryPoint || "";
   }
 
   // sha1, sha256, or sha512
   if (!options.signatureAlgorithm) {
-    options.signatureAlgorithm = 'sha1';
+    options.signatureAlgorithm = "sha1";
   }
 
   return options;
 };
 
-SAML.prototype.getProtocol = function (req) {
-  return this.options.protocol || (req.protocol || 'http').concat('://');
+SAML.prototype.getProtocol = function(req) {
+  return this.options.protocol || (req.protocol || "http").concat("://");
 };
 
-SAML.prototype.getCallbackUrl = function (req) {
-    // Post-auth destination
+SAML.prototype.getCallbackUrl = function(req) {
+  // Post-auth destination
   if (this.options.callbackUrl) {
     return this.options.callbackUrl;
   } else {
@@ -93,29 +97,29 @@ SAML.prototype.getCallbackUrl = function (req) {
   }
 };
 
-SAML.prototype.generateUniqueID = function () {
-  return crypto.randomBytes(10).toString('hex');
+SAML.prototype.generateUniqueID = function() {
+  return crypto.randomBytes(10).toString("hex");
 };
 
-SAML.prototype.generateInstant = function () {
+SAML.prototype.generateInstant = function() {
   return new Date().toISOString();
 };
 
-SAML.prototype.signRequest = function (samlMessage) {
+SAML.prototype.signRequest = function(samlMessage) {
   var signer;
   var samlMessageToSign = {};
-  switch(this.options.signatureAlgorithm) {
-    case 'sha256':
-      samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
-      signer = crypto.createSign('RSA-SHA256');
+  switch (this.options.signatureAlgorithm) {
+    case "sha256":
+      samlMessage.SigAlg = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+      signer = crypto.createSign("RSA-SHA256");
       break;
-    case 'sha512':
-      samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
-      signer = crypto.createSign('RSA-SHA512');
+    case "sha512":
+      samlMessage.SigAlg = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+      signer = crypto.createSign("RSA-SHA512");
       break;
     default:
-      samlMessage.SigAlg = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
-      signer = crypto.createSign('RSA-SHA1');
+      samlMessage.SigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+      signer = crypto.createSign("RSA-SHA1");
       break;
   }
   if (samlMessage.SAMLRequest) {
@@ -131,141 +135,144 @@ SAML.prototype.signRequest = function (samlMessage) {
     samlMessageToSign.SigAlg = samlMessage.SigAlg;
   }
   signer.update(querystring.stringify(samlMessageToSign));
-  samlMessage.Signature = signer.sign(this.options.privateCert, 'base64');
+  samlMessage.Signature = signer.sign(this.options.privateCert, "base64");
 };
 
-SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
+SAML.prototype.generateAuthorizeRequest = function(req, isPassive, callback) {
   var self = this;
   var id = "_" + self.generateUniqueID();
   var instant = self.generateInstant();
   var forceAuthn = self.options.forceAuthn || false;
 
   Q.fcall(function() {
-    if(self.options.validateInResponseTo) {
-      return Q.ninvoke(self.cacheProvider, 'save', id, instant);
+    if (self.options.validateInResponseTo) {
+      return Q.ninvoke(self.cacheProvider, "save", id, instant);
     } else {
       return Q();
     }
   })
-  .then(function(){
-    var request = {
-      'samlp:AuthnRequest': {
-        '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-        '@ID': id,
-        '@Version': '2.0',
-        '@IssueInstant': instant,
-        '@ProtocolBinding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-        '@AssertionConsumerServiceURL': self.getCallbackUrl(req),
-        '@Destination': self.options.entryPoint,
-        'saml:Issuer' : {
-          '@xmlns:saml' : 'urn:oasis:names:tc:SAML:2.0:assertion',
-          '#text': self.options.issuer
+    .then(function() {
+      var request = {
+        "samlp:AuthnRequest": {
+          "@xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          "@ID": id,
+          "@Version": "2.0",
+          "@IssueInstant": instant,
+          "@ProtocolBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+          "@AssertionConsumerServiceURL": self.getCallbackUrl(req),
+          "@Destination": self.options.entryPoint,
+          "saml:Issuer": {
+            "@xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+            "#text": self.options.issuer
+          }
         }
+      };
+
+      if (isPassive) request["samlp:AuthnRequest"]["@IsPassive"] = true;
+
+      if (forceAuthn) {
+        request["samlp:AuthnRequest"]["@ForceAuthn"] = true;
       }
-    };
 
-    if (isPassive)
-      request['samlp:AuthnRequest']['@IsPassive'] = true;
+      if (self.options.identifierFormat) {
+        request["samlp:AuthnRequest"]["samlp:NameIDPolicy"] = {
+          "@xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          "@Format": self.options.identifierFormat,
+          "@AllowCreate": "true"
+        };
+      }
 
-    if (forceAuthn) {
-      request['samlp:AuthnRequest']['@ForceAuthn'] = true;
-    }
+      if (!self.options.disableRequestedAuthnContext) {
+        request["samlp:AuthnRequest"]["samlp:RequestedAuthnContext"] = {
+          "@xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          "@Comparison": "exact",
+          "saml:AuthnContextClassRef": {
+            "@xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+            "#text": self.options.authnContext
+          }
+        };
+      }
 
-    if (self.options.identifierFormat) {
-      request['samlp:AuthnRequest']['samlp:NameIDPolicy'] = {
-        '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-        '@Format': self.options.identifierFormat,
-        '@AllowCreate': 'true'
-      };
-    }
+      if (self.options.attributeConsumingServiceIndex) {
+        request["samlp:AuthnRequest"]["@AttributeConsumingServiceIndex"] =
+          self.options.attributeConsumingServiceIndex;
+      }
 
-    if (!self.options.disableRequestedAuthnContext) {
-      request['samlp:AuthnRequest']['samlp:RequestedAuthnContext'] = {
-        '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-        '@Comparison': 'exact',
-        'saml:AuthnContextClassRef': {
-          '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-          '#text': self.options.authnContext
-        }
-      };
-    }
+      if (self.options.providerName) {
+        request["samlp:AuthnRequest"]["@ProviderName"] =
+          self.options.providerName;
+      }
 
-    if (self.options.attributeConsumingServiceIndex) {
-      request['samlp:AuthnRequest']['@AttributeConsumingServiceIndex'] = self.options.attributeConsumingServiceIndex;
-    }
-
-    if (self.options.providerName) {
-      request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
-    }
-
-    callback(null, xmlbuilder.create(request).end());
-  })
-  .fail(function(err){
-    callback(err);
-  })
-  .done();
+      callback(null, xmlbuilder.create(request).end());
+    })
+    .fail(function(err) {
+      callback(err);
+    })
+    .done();
 };
 
-SAML.prototype.generateLogoutRequest = function (req) {
+SAML.prototype.generateLogoutRequest = function(req) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
 
   var request = {
-    'samlp:LogoutRequest' : {
-      '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-      '@ID': id,
-      '@Version': '2.0',
-      '@IssueInstant': instant,
-      '@Destination': this.options.logoutUrl,
-      'saml:Issuer' : {
-        '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-        '#text': this.options.issuer
+    "samlp:LogoutRequest": {
+      "@xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+      "@xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+      "@ID": id,
+      "@Version": "2.0",
+      "@IssueInstant": instant,
+      "@Destination": this.options.logoutUrl,
+      "saml:Issuer": {
+        "@xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+        "#text": this.options.issuer
       },
-      'saml:NameID' : {
-        '@Format': req.user.nameIDFormat,
-        '#text': req.user.nameID
+      "saml:NameID": {
+        "@Format": req.user.nameIDFormat,
+        "#text": req.user.nameID
       }
     }
   };
 
-  if (typeof(req.user.nameQualifier) !== 'undefined') {
-    request['samlp:LogoutRequest']['saml:NameID']['@NameQualifier'] = req.user.nameQualifier;
+  if (typeof req.user.nameQualifier !== "undefined") {
+    request["samlp:LogoutRequest"]["saml:NameID"]["@NameQualifier"] =
+      req.user.nameQualifier;
   }
 
-  if (typeof(req.user.spNameQualifier) !== 'undefined') {
-    request['samlp:LogoutRequest']['saml:NameID']['@SPNameQualifier'] = req.user.spNameQualifier;
+  if (typeof req.user.spNameQualifier !== "undefined") {
+    request["samlp:LogoutRequest"]["saml:NameID"]["@SPNameQualifier"] =
+      req.user.spNameQualifier;
   }
 
   if (req.user.sessionIndex) {
-    request['samlp:LogoutRequest']['saml2p:SessionIndex'] = {
-      '@xmlns:saml2p': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      '#text': req.user.sessionIndex
+    request["samlp:LogoutRequest"]["saml2p:SessionIndex"] = {
+      "@xmlns:saml2p": "urn:oasis:names:tc:SAML:2.0:protocol",
+      "#text": req.user.sessionIndex
     };
   }
 
   return xmlbuilder.create(request).end();
 };
 
-SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
+SAML.prototype.generateLogoutResponse = function(req, logoutRequest) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
 
   var request = {
-    'samlp:LogoutResponse' : {
-      '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
-      '@ID': id,
-      '@Version': '2.0',
-      '@IssueInstant': instant,
-      '@Destination': this.options.logoutUrl,
-      '@InResponseTo': logoutRequest.ID,
-      'saml:Issuer' : {
-        '#text': this.options.issuer
+    "samlp:LogoutResponse": {
+      "@xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+      "@xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+      "@ID": id,
+      "@Version": "2.0",
+      "@IssueInstant": instant,
+      "@Destination": this.options.logoutUrl,
+      "@InResponseTo": logoutRequest.ID,
+      "saml:Issuer": {
+        "#text": this.options.issuer
       },
-      'samlp:Status': {
-        'samlp:StatusCode': {
-          '@Value': 'urn:oasis:names:tc:SAML:2.0:status:Success'
+      "samlp:Status": {
+        "samlp:StatusCode": {
+          "@Value": "urn:oasis:names:tc:SAML:2.0:status:Success"
         }
       }
     }
@@ -274,34 +281,41 @@ SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
   return xmlbuilder.create(request).end();
 };
 
-SAML.prototype.requestToUrl = function (request, response, operation, additionalParameters, callback) {
+SAML.prototype.requestToUrl = function(
+  request,
+  response,
+  operation,
+  additionalParameters,
+  callback
+) {
   var self = this;
   if (self.options.skipRequestCompression)
-    requestToUrlHelper(null, new Buffer(request || response, 'utf8'));
-  else
-    zlib.deflateRaw(request || response, requestToUrlHelper);
+    requestToUrlHelper(null, new Buffer(request || response, "utf8"));
+  else zlib.deflateRaw(request || response, requestToUrlHelper);
 
   function requestToUrlHelper(err, buffer) {
     if (err) {
       return callback(err);
     }
 
-    var base64 = buffer.toString('base64');
+    var base64 = buffer.toString("base64");
     var target = url.parse(self.options.entryPoint, true);
 
-    if (operation === 'logout') {
+    if (operation === "logout") {
       if (self.options.logoutUrl) {
         target = url.parse(self.options.logoutUrl, true);
       }
-    } else if (operation !== 'authorize') {
-        return callback(new Error("Unknown operation: "+operation));
+    } else if (operation !== "authorize") {
+      return callback(new Error("Unknown operation: " + operation));
     }
 
-    var samlMessage = request ? {
-      SAMLRequest: base64
-    } : {
-      SAMLResponse: base64
-    };
+    var samlMessage = request
+      ? {
+          SAMLRequest: base64
+        }
+      : {
+          SAMLResponse: base64
+        };
     Object.keys(additionalParameters).forEach(function(k) {
       samlMessage[k] = additionalParameters[k];
     });
@@ -326,10 +340,11 @@ SAML.prototype.requestToUrl = function (request, response, operation, additional
   }
 };
 
-SAML.prototype.getAdditionalParams = function (req, operation) {
+SAML.prototype.getAdditionalParams = function(req, operation) {
   var additionalParams = {};
 
-  var RelayState = req.query && req.query.RelayState || req.body && req.body.RelayState;
+  var RelayState =
+    (req.query && req.query.RelayState) || (req.body && req.body.RelayState);
   if (RelayState) {
     additionalParams.RelayState = RelayState;
   }
@@ -341,10 +356,12 @@ SAML.prototype.getAdditionalParams = function (req, operation) {
 
   var optionsAdditionalParamsForThisOperation = {};
   if (operation == "authorize") {
-    optionsAdditionalParamsForThisOperation = this.options.additionalAuthorizeParams || {};
+    optionsAdditionalParamsForThisOperation =
+      this.options.additionalAuthorizeParams || {};
   }
   if (operation == "logout") {
-    optionsAdditionalParamsForThisOperation = this.options.additionalLogoutParams || {};
+    optionsAdditionalParamsForThisOperation =
+      this.options.additionalLogoutParams || {};
   }
 
   Object.keys(optionsAdditionalParamsForThisOperation).forEach(function(k) {
@@ -354,34 +371,44 @@ SAML.prototype.getAdditionalParams = function (req, operation) {
   return additionalParams;
 };
 
-SAML.prototype.getAuthorizeUrl = function (req, callback) {
+SAML.prototype.getAuthorizeUrl = function(req, callback) {
   var self = this;
-  self.generateAuthorizeRequest(req, self.options.passive, function(err, request){
-    if (err)
-      return callback(err);
-    var operation = 'authorize';
-    self.requestToUrl(request, null, operation, self.getAdditionalParams(req, operation), callback);
+  self.generateAuthorizeRequest(req, self.options.passive, function(
+    err,
+    request
+  ) {
+    if (err) return callback(err);
+    var operation = "authorize";
+    self.requestToUrl(
+      request,
+      null,
+      operation,
+      self.getAdditionalParams(req, operation),
+      callback
+    );
   });
 };
 
-SAML.prototype.getAuthorizeForm = function (req, callback) {
+SAML.prototype.getAuthorizeForm = function(req, callback) {
   var self = this;
 
   // The quoteattr() function is used in a context, where the result will not be evaluated by javascript
   // but must be interpreted by an XML or HTML parser, and it must absolutely avoid breaking the syntax
   // of an element attribute.
   var quoteattr = function(s, preserveCR) {
-    preserveCR = preserveCR ? '&#13;' : '\n';
-    return ('' + s) // Forces the conversion to string.
-      .replace(/&/g, '&amp;') // This MUST be the 1st replacement.
-      .replace(/'/g, '&apos;') // The 4 other predefined entities, required.
-      .replace(/"/g, '&quot;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-       // Add other replacements here for HTML only
-       // Or for XML, only if the named entities are defined in its DTD.
-      .replace(/\r\n/g, preserveCR) // Must be before the next replacement.
-      .replace(/[\r\n]/g, preserveCR);
+    preserveCR = preserveCR ? "&#13;" : "\n";
+    return (
+      ("" + s) // Forces the conversion to string.
+        .replace(/&/g, "&amp;") // This MUST be the 1st replacement.
+        .replace(/'/g, "&apos;") // The 4 other predefined entities, required.
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        // Add other replacements here for HTML only
+        // Or for XML, only if the named entities are defined in its DTD.
+        .replace(/\r\n/g, preserveCR) // Must be before the next replacement.
+        .replace(/[\r\n]/g, preserveCR)
+    );
   };
 
   var getAuthorizeFormHelper = function(err, buffer) {
@@ -389,86 +416,112 @@ SAML.prototype.getAuthorizeForm = function (req, callback) {
       return callback(err);
     }
 
-    var operation = 'authorize';
+    var operation = "authorize";
     var additionalParameters = self.getAdditionalParams(req, operation);
     var samlMessage = {
-      SAMLRequest: buffer.toString('base64')
+      SAMLRequest: buffer.toString("base64")
     };
 
     Object.keys(additionalParameters).forEach(function(k) {
-      samlMessage[k] = additionalParameters[k] || '';
+      samlMessage[k] = additionalParameters[k] || "";
     });
 
-    var formInputs = Object.keys(samlMessage).map(function(k) {
-      return '<input type="hidden" name="' + k + '" value="' + quoteattr(samlMessage[k]) + '" />';
-    }).join('\r\n');
+    var formInputs = Object.keys(samlMessage)
+      .map(function(k) {
+        return (
+          '<input type="hidden" name="' +
+          k +
+          '" value="' +
+          quoteattr(samlMessage[k]) +
+          '" />'
+        );
+      })
+      .join("\r\n");
 
-    callback(null, [
-      '<!DOCTYPE html>',
-      '<html>',
-      '<head>',
-      '<meta charset="utf-8">',
-      '<meta http-equiv="x-ua-compatible" content="ie=edge">',
-      '</head>',
-      '<body onload="document.forms[0].submit()">',
-      '<noscript>',
-      '<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p>',
-      '</noscript>',
-      '<form method="post" action="' + encodeURI(self.options.entryPoint) + '">',
-      formInputs,
-      '<input type="submit" value="Submit" />',
-      '</form>',
-      '<script>document.forms[0].style.display="none";</script>', // Hide the form if JavaScript is enabled
-      '</body>',
-      '</html>'
-    ].join('\r\n'));
+    callback(
+      null,
+      [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '<meta charset="utf-8">',
+        '<meta http-equiv="x-ua-compatible" content="ie=edge">',
+        "</head>",
+        '<body onload="document.forms[0].submit()">',
+        "<noscript>",
+        "<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p>",
+        "</noscript>",
+        '<form method="post" action="' +
+          encodeURI(self.options.entryPoint) +
+          '">',
+        formInputs,
+        '<input type="submit" value="Submit" />',
+        "</form>",
+        '<script>document.forms[0].style.display="none";</script>', // Hide the form if JavaScript is enabled
+        "</body>",
+        "</html>"
+      ].join("\r\n")
+    );
   };
 
-  self.generateAuthorizeRequest(req, self.options.passive, function(err, request) {
+  self.generateAuthorizeRequest(req, self.options.passive, function(
+    err,
+    request
+  ) {
     if (err) {
       return callback(err);
     }
 
     if (self.options.skipRequestCompression) {
-      getAuthorizeFormHelper(null, new Buffer(request, 'utf8'));
+      getAuthorizeFormHelper(null, new Buffer(request, "utf8"));
     } else {
       zlib.deflateRaw(request, getAuthorizeFormHelper);
     }
   });
-
 };
 
 SAML.prototype.getLogoutUrl = function(req, callback) {
   var request = this.generateLogoutRequest(req);
-  var operation = 'logout';
-  this.requestToUrl(request, null, operation, this.getAdditionalParams(req, operation), callback);
+  var operation = "logout";
+  this.requestToUrl(
+    request,
+    null,
+    operation,
+    this.getAdditionalParams(req, operation),
+    callback
+  );
 };
 
 SAML.prototype.getLogoutResponseUrl = function(req, callback) {
   var response = this.generateLogoutResponse(req, req.samlLogoutRequest);
-  var operation = 'logout';
-  this.requestToUrl(null, response, operation, this.getAdditionalParams(req, operation), callback);
+  var operation = "logout";
+  this.requestToUrl(
+    null,
+    response,
+    operation,
+    this.getAdditionalParams(req, operation),
+    callback
+  );
 };
 
-SAML.prototype.certToPEM = function (cert) {
-  cert = cert.match(/.{1,64}/g).join('\n');
+SAML.prototype.certToPEM = function(cert) {
+  cert = cert.match(/.{1,64}/g).join("\n");
 
-  if (cert.indexOf('-BEGIN CERTIFICATE-') === -1)
+  if (cert.indexOf("-BEGIN CERTIFICATE-") === -1)
     cert = "-----BEGIN CERTIFICATE-----\n" + cert;
-  if (cert.indexOf('-END CERTIFICATE-') === -1)
+  if (cert.indexOf("-END CERTIFICATE-") === -1)
     cert = cert + "\n-----END CERTIFICATE-----\n";
 
   return cert;
 };
 
-SAML.prototype.certsToCheck = function () {
+SAML.prototype.certsToCheck = function() {
   var self = this;
   if (!self.options.cert) {
     return Q();
   }
-  if (typeof(self.options.cert) === 'function') {
-    return Q.nfcall(self.options.cert)
-    .then(function(certs) {
+  if (typeof self.options.cert === "function") {
+    return Q.nfcall(self.options.cert).then(function(certs) {
       if (!Array.isArray(certs)) {
         certs = [certs];
       }
@@ -487,148 +540,186 @@ SAML.prototype.certsToCheck = function () {
 //
 // See https://github.com/bergie/passport-saml/issues/19 for references to some of the attack
 //   vectors against SAML signature verification.
-SAML.prototype.validateSignature = function (fullXml, currentNode, certs) {
+SAML.prototype.validateSignature = function(fullXml, currentNode, certs) {
   var self = this;
-  var xpathSigQuery = ".//*[local-name(.)='Signature' and " +
-                      "namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']";
+  var xpathSigQuery =
+    ".//*[local-name(.)='Signature' and " +
+    "namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']";
   var signatures = xpath(currentNode, xpathSigQuery);
   // This function is expecting to validate exactly one signature, so if we find more or fewer
   //   than that, reject.
-  if (signatures.length != 1)
-    return false;
+  if (signatures.length != 1) return false;
   var signature = signatures[0];
-  return certs.some(function (certToCheck) {
-    return self.validateSignatureForCert(signature, certToCheck, fullXml, currentNode);
+  return certs.some(function(certToCheck) {
+    return self.validateSignatureForCert(
+      signature,
+      certToCheck,
+      fullXml,
+      currentNode
+    );
   });
 };
 
 // This function checks that the |signature| is signed with a given |cert|.
-SAML.prototype.validateSignatureForCert = function (signature, cert, fullXml, currentNode) {
+SAML.prototype.validateSignatureForCert = function(
+  signature,
+  cert,
+  fullXml,
+  currentNode
+) {
   var self = this;
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
-    getKeyInfo: function (key) {
+    getKeyInfo: function(key) {
       return "<X509Data></X509Data>";
     },
-    getKey: function (keyInfo) {
+    getKey: function(keyInfo) {
       return self.certToPEM(cert);
     }
   };
   sig.loadSignature(signature);
   // We expect each signature to contain exactly one reference to the top level of the xml we
   //   are validating, so if we see anything else, reject.
-  if (sig.references.length != 1 )
-    return false;
+  if (sig.references.length != 1) return false;
   var refUri = sig.references[0].uri;
-  var refId = (refUri[0] === '#') ? refUri.substring(1) : refUri;
+  var refId = refUri[0] === "#" ? refUri.substring(1) : refUri;
   // If we can't find the reference at the top level, reject
-  var idAttribute = currentNode.getAttribute('ID') ? 'ID' : 'Id';
-  if (currentNode.getAttribute(idAttribute) != refId)
-    return false;
+  var idAttribute = currentNode.getAttribute("ID") ? "ID" : "Id";
+  if (currentNode.getAttribute(idAttribute) != refId) return false;
   // If we find any extra referenced nodes, reject.  (xml-crypto only verifies one digest, so
   //   multiple candidate references is bad news)
-  var totalReferencedNodes = xpath(currentNode.ownerDocument,
-                                  "//*[@" + idAttribute + "='" + refId + "']");
-  if (totalReferencedNodes.length > 1)
-    return false;
+  var totalReferencedNodes = xpath(
+    currentNode.ownerDocument,
+    "//*[@" + idAttribute + "='" + refId + "']"
+  );
+  if (totalReferencedNodes.length > 1) return false;
   return sig.checkSignature(fullXml);
 };
 
-SAML.prototype.validatePostResponse = function (container, callback) {
+SAML.prototype.validatePostResponse = function(container, callback) {
   var self = this;
 
   var xml, doc, inResponseTo;
 
-  Q.fcall(function(){
-    xml = new Buffer(container.SAMLResponse, 'base64').toString('utf8');
-    doc = new xmldom.DOMParser({
-    }).parseFromString(xml);
+  Q.fcall(function() {
+    xml = new Buffer(container.SAMLResponse, "base64").toString("utf8");
+    doc = new xmldom.DOMParser({}).parseFromString(xml);
 
-    if (!doc.hasOwnProperty('documentElement'))
-      throw new Error('SAMLResponse is not valid base64-encoded XML');
+    if (!doc.hasOwnProperty("documentElement"))
+      throw new Error("SAMLResponse is not valid base64-encoded XML");
 
     inResponseTo = xpath(doc, "/*[local-name()='Response']/@InResponseTo");
 
-    if(inResponseTo){
+    if (inResponseTo) {
       inResponseTo = inResponseTo.length ? inResponseTo[0].nodeValue : null;
     }
 
-    if(self.options.validateInResponseTo){
+    if (self.options.validateInResponseTo) {
       if (inResponseTo) {
-        return Q.ninvoke(self.cacheProvider, 'get', inResponseTo)
-          .then(function(result) {
-            if (!result)
-              throw new Error('InResponseTo is not valid');
-            return Q();
-          });
+        return Q.ninvoke(self.cacheProvider, "get", inResponseTo).then(function(
+          result
+        ) {
+          if (!result) throw new Error("InResponseTo is not valid");
+          return Q();
+        });
       }
     } else {
       return Q();
     }
   })
-  .then(function() {
-    return self.certsToCheck();
-  })
-  .then(function(certs) {
-    // Check if this document has a valid top-level signature
-    var validSignature = false;
-    if (self.options.cert && self.validateSignature(xml, doc.documentElement, certs)) {
-      validSignature = true;
-    }
-
-    var assertions = xpath(doc, "/*[local-name()='Response']/*[local-name()='Assertion']");
-    var encryptedAssertions = xpath(doc,
-      "/*[local-name()='Response']/*[local-name()='EncryptedAssertion']");
-
-    if (assertions.length + encryptedAssertions.length > 1) {
-      // There's no reason I know of that we want to handle multiple assertions, and it seems like a
-      //   potential risk vector for signature scope issues, so treat this as an invalid signature
-      throw new Error('Invalid signature');
-    }
-
-    if (assertions.length == 1) {
-      if (self.options.cert &&
-          !validSignature &&
-          !self.validateSignature(xml, assertions[0], certs)) {
-        throw new Error('Invalid signature');
+    .then(function() {
+      return self.certsToCheck();
+    })
+    .then(function(certs) {
+      // Check if this document has a valid top-level signature
+      var validSignature = false;
+      if (
+        self.options.cert &&
+        self.validateSignature(xml, doc.documentElement, certs)
+      ) {
+        validSignature = true;
       }
-      return self.processValidlySignedAssertion(assertions[0].toString(), inResponseTo, callback);
-    }
 
-    if (encryptedAssertions.length == 1) {
-      if (!self.options.decryptionPvk)
-        throw new Error('No decryption key for encrypted SAML response');
+      var assertions = xpath(
+        doc,
+        "/*[local-name()='Response']/*[local-name()='Assertion']"
+      );
+      var encryptedAssertions = xpath(
+        doc,
+        "/*[local-name()='Response']/*[local-name()='EncryptedAssertion']"
+      );
 
-      var encryptedAssertionXml = encryptedAssertions[0].toString();
+      if (assertions.length + encryptedAssertions.length > 1) {
+        // There's no reason I know of that we want to handle multiple assertions, and it seems like a
+        //   potential risk vector for signature scope issues, so treat this as an invalid signature
+        throw new Error("Invalid signature");
+      }
 
-      var xmlencOptions = { key: self.options.decryptionPvk };
-      return Q.ninvoke(xmlenc, 'decrypt', encryptedAssertionXml, xmlencOptions)
-        .then(function(decryptedXml) {
-          var decryptedDoc = new xmldom.DOMParser().parseFromString(decryptedXml);
-          var decryptedAssertions = xpath(decryptedDoc, "/*[local-name()='Assertion']");
+      if (assertions.length == 1) {
+        if (
+          self.options.cert &&
+          !validSignature &&
+          !self.validateSignature(xml, assertions[0], certs)
+        ) {
+          throw new Error("Invalid signature");
+        }
+        return self.processValidlySignedAssertion(
+          xml,
+          assertions[0].toString(),
+          inResponseTo,
+          callback
+        );
+      }
+
+      if (encryptedAssertions.length == 1) {
+        if (!self.options.decryptionPvk)
+          throw new Error("No decryption key for encrypted SAML response");
+
+        var encryptedAssertionXml = encryptedAssertions[0].toString();
+
+        var xmlencOptions = { key: self.options.decryptionPvk };
+        return Q.ninvoke(
+          xmlenc,
+          "decrypt",
+          encryptedAssertionXml,
+          xmlencOptions
+        ).then(function(decryptedXml) {
+          var decryptedDoc = new xmldom.DOMParser().parseFromString(
+            decryptedXml
+          );
+          var decryptedAssertions = xpath(
+            decryptedDoc,
+            "/*[local-name()='Assertion']"
+          );
           if (decryptedAssertions.length != 1)
-            throw new Error('Invalid EncryptedAssertion content');
+            throw new Error("Invalid EncryptedAssertion content");
 
-          if (self.options.cert &&
-              !validSignature &&
-              !self.validateSignature(decryptedXml, decryptedAssertions[0], certs))
-            throw new Error('Invalid signature');
+          if (
+            self.options.cert &&
+            !validSignature &&
+            !self.validateSignature(decryptedXml, decryptedAssertions[0], certs)
+          )
+            throw new Error("Invalid signature");
 
-          self.processValidlySignedAssertion(decryptedAssertions[0].toString(), inResponseTo, callback);
+          self.processValidlySignedAssertion(
+            xml,
+            decryptedAssertions[0].toString(),
+            inResponseTo,
+            callback
+          );
         });
-    }
+      }
 
-    // If there's no assertion, fall back on xml2js response parsing for the status &
-    //   LogoutResponse code.
+      // If there's no assertion, fall back on xml2js response parsing for the status &
+      //   LogoutResponse code.
 
-    var parserConfig = {
-      explicitRoot: true,
-      explicitCharkey: true,
-      tagNameProcessors: [xml2js.processors.stripPrefix]
-    };
-    var parser = new xml2js.Parser(parserConfig);
-    return Q.ninvoke( parser, 'parseString', xml)
-      .then(function(doc) {
+      var parserConfig = {
+        explicitRoot: true,
+        explicitCharkey: true,
+        tagNameProcessors: [xml2js.processors.stripPrefix]
+      };
+      var parser = new xml2js.Parser(parserConfig);
+      return Q.ninvoke(parser, "parseString", xml).then(function(doc) {
         var response = doc.Response;
         if (response) {
           var assertion = response.Assertion;
@@ -636,11 +727,19 @@ SAML.prototype.validatePostResponse = function (container, callback) {
             var status = response.Status;
             if (status) {
               var statusCode = status[0].StatusCode;
-              if (statusCode && statusCode[0].$.Value === "urn:oasis:names:tc:SAML:2.0:status:Responder") {
+              if (
+                statusCode &&
+                statusCode[0].$.Value ===
+                  "urn:oasis:names:tc:SAML:2.0:status:Responder"
+              ) {
                 var nestedStatusCode = statusCode[0].StatusCode;
-                if (nestedStatusCode && nestedStatusCode[0].$.Value === "urn:oasis:names:tc:SAML:2.0:status:NoPassive") {
+                if (
+                  nestedStatusCode &&
+                  nestedStatusCode[0].$.Value ===
+                    "urn:oasis:names:tc:SAML:2.0:status:NoPassive"
+                ) {
                   if (self.options.cert && !validSignature) {
-                    throw new Error('Invalid signature');
+                    throw new Error("Invalid signature");
                   }
                   return callback(null, null, false);
                 }
@@ -651,45 +750,56 @@ SAML.prototype.validatePostResponse = function (container, callback) {
               //   let's go ahead and give the potentially more helpful error.
               if (statusCode && statusCode[0].$.Value) {
                 var msgType = statusCode[0].$.Value.match(/[^:]*$/)[0];
-                if (msgType != 'Success') {
-                  var msg = 'unspecified';
+                if (msgType != "Success") {
+                  var msg = "unspecified";
                   if (status[0].StatusMessage) {
                     msg = status[0].StatusMessage[0]._;
                   } else if (statusCode[0].StatusCode) {
-                    msg = statusCode[0].StatusCode[0].$.Value.match(/[^:]*$/)[0];
+                    msg = statusCode[0].StatusCode[0].$.Value.match(
+                      /[^:]*$/
+                    )[0];
                   }
-                  var error = new Error('SAML provider returned ' + msgType + ' error: ' + msg);
+                  var error = new Error(
+                    "SAML provider returned " + msgType + " error: " + msg
+                  );
                   var builderOpts = {
-                    rootName: 'Status',
+                    rootName: "Status",
                     headless: true
                   };
-                  error.statusXml = new xml2js.Builder(builderOpts).buildObject(status[0]);
+                  error.statusXml = new xml2js.Builder(builderOpts).buildObject(
+                    status[0]
+                  );
                   throw error;
                 }
               }
             }
-            throw new Error('Missing SAML assertion');
+            throw new Error("Missing SAML assertion");
           }
         } else {
           if (self.options.cert && !validSignature) {
-            throw new Error('Invalid signature');
+            throw new Error("Invalid signature");
           }
           var logoutResponse = doc.LogoutResponse;
-          if (logoutResponse){
+          if (logoutResponse) {
             return callback(null, null, true);
           } else {
-            throw new Error('Unknown SAML response message');
+            throw new Error("Unknown SAML response message");
           }
         }
       });
-  })
-  .fail(function(err) {
-    callback(err);
-  })
-  .done();
+    })
+    .fail(function(err) {
+      callback(err);
+    })
+    .done();
 };
 
-SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callback) {
+SAML.prototype.processValidlySignedAssertion = function(
+  samlResponse,
+  xml,
+  inResponseTo,
+  callback
+) {
   var self = this;
   var msg;
   var parserConfig = {
@@ -700,326 +810,374 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
   var profile = {};
   var assertion;
   var parser = new xml2js.Parser(parserConfig);
-  Q.ninvoke(parser, 'parseString', xml)
-  .then(function(doc) {
-    assertion = doc.Assertion;
+  Q.ninvoke(parser, "parseString", xml)
+    .then(function(doc) {
+      assertion = doc.Assertion;
 
-    var issuer = assertion.Issuer;
-    if (issuer) {
-      profile.issuer = issuer[0];
-    }
-
-    var authnStatement = assertion.AuthnStatement;
-    if (authnStatement) {
-      if (authnStatement[0].$ && authnStatement[0].$.SessionIndex) {
-        profile.sessionIndex = authnStatement[0].$.SessionIndex;
+      var issuer = assertion.Issuer;
+      if (issuer) {
+        profile.issuer = issuer[0];
       }
-    }
 
-    var subject = assertion.Subject;
-    var subjectConfirmation, confirmData;
-    if (subject) {
-      var nameID = subject[0].NameID;
-      if (nameID) {
-        profile.nameID = nameID[0]._ || nameID[0];
-
-        if (nameID[0].$ && nameID[0].$.Format) {
-          profile.nameIDFormat = nameID[0].$.Format;
-          profile.nameQualifier = nameID[0].$.NameQualifier;
-          profile.spNameQualifier = nameID[0].$.SPNameQualifier;
+      var authnStatement = assertion.AuthnStatement;
+      if (authnStatement) {
+        if (authnStatement[0].$ && authnStatement[0].$.SessionIndex) {
+          profile.sessionIndex = authnStatement[0].$.SessionIndex;
         }
       }
 
-      subjectConfirmation = subject[0].SubjectConfirmation ?
-                            subject[0].SubjectConfirmation[0] : null;
-      confirmData = subjectConfirmation && subjectConfirmation.SubjectConfirmationData ?
-                    subjectConfirmation.SubjectConfirmationData[0] : null;
-      if (subject[0].SubjectConfirmation && subject[0].SubjectConfirmation.length > 1) {
-        msg = 'Unable to process multiple SubjectConfirmations in SAML assertion';
-        throw new Error(msg);
-      }
+      var subject = assertion.Subject;
+      var subjectConfirmation, confirmData;
+      if (subject) {
+        var nameID = subject[0].NameID;
+        if (nameID) {
+          profile.nameID = nameID[0]._ || nameID[0];
 
-      if (subjectConfirmation) {
-        if (confirmData && confirmData.$) {
-          var subjectNotBefore = confirmData.$.NotBefore;
-          var subjectNotOnOrAfter = confirmData.$.NotOnOrAfter;
+          if (nameID[0].$ && nameID[0].$.Format) {
+            profile.nameIDFormat = nameID[0].$.Format;
+            profile.nameQualifier = nameID[0].$.NameQualifier;
+            profile.spNameQualifier = nameID[0].$.SPNameQualifier;
+          }
+        }
 
-          var subjErr = self.checkTimestampsValidityError(
-                          nowMs, subjectNotBefore, subjectNotOnOrAfter);
-          if (subjErr) {
-            throw subjErr;
+        subjectConfirmation = subject[0].SubjectConfirmation
+          ? subject[0].SubjectConfirmation[0]
+          : null;
+        confirmData =
+          subjectConfirmation && subjectConfirmation.SubjectConfirmationData
+            ? subjectConfirmation.SubjectConfirmationData[0]
+            : null;
+        if (
+          subject[0].SubjectConfirmation &&
+          subject[0].SubjectConfirmation.length > 1
+        ) {
+          msg =
+            "Unable to process multiple SubjectConfirmations in SAML assertion";
+          throw new Error(msg);
+        }
+
+        if (subjectConfirmation) {
+          if (confirmData && confirmData.$) {
+            var subjectNotBefore = confirmData.$.NotBefore;
+            var subjectNotOnOrAfter = confirmData.$.NotOnOrAfter;
+
+            var subjErr = self.checkTimestampsValidityError(
+              nowMs,
+              subjectNotBefore,
+              subjectNotOnOrAfter
+            );
+            if (subjErr) {
+              throw subjErr;
+            }
           }
         }
       }
-    }
 
-    // Test to see that if we have a SubjectConfirmation InResponseTo that it matches
-    // the 'InResponseTo' attribute set in the Response
-    if (self.options.validateInResponseTo) {
-      if (subjectConfirmation) {
-        if (confirmData && confirmData.$) {
-          var subjectInResponseTo = confirmData.$.InResponseTo;
-          if (inResponseTo && subjectInResponseTo && subjectInResponseTo != inResponseTo) {
-            return Q.ninvoke(self.cacheProvider, 'remove', inResponseTo)
-              .then(function(){
-                throw new Error('InResponseTo is not valid');
-              });
-          } else if (subjectInResponseTo) {
-            var foundValidInResponseTo = false;
-            return Q.ninvoke(self.cacheProvider, 'get', subjectInResponseTo)
-              .then(function(result){
-                if (result) {
-                  var createdAt = new Date(result);
-                  if (nowMs < createdAt.getTime() + self.options.requestIdExpirationPeriodMs)
-                    foundValidInResponseTo = true;
+      // Test to see that if we have a SubjectConfirmation InResponseTo that it matches
+      // the 'InResponseTo' attribute set in the Response
+      if (self.options.validateInResponseTo) {
+        if (subjectConfirmation) {
+          if (confirmData && confirmData.$) {
+            var subjectInResponseTo = confirmData.$.InResponseTo;
+            if (
+              inResponseTo &&
+              subjectInResponseTo &&
+              subjectInResponseTo != inResponseTo
+            ) {
+              return Q.ninvoke(self.cacheProvider, "remove", inResponseTo).then(
+                function() {
+                  throw new Error("InResponseTo is not valid");
                 }
-                return Q.ninvoke(self.cacheProvider, 'remove', inResponseTo );
-              })
-              .then(function(){
-                if (!foundValidInResponseTo) {
-                  throw new Error('InResponseTo is not valid');
-                }
-                return Q();
-              });
+              );
+            } else if (subjectInResponseTo) {
+              var foundValidInResponseTo = false;
+              return Q.ninvoke(self.cacheProvider, "get", subjectInResponseTo)
+                .then(function(result) {
+                  if (result) {
+                    var createdAt = new Date(result);
+                    if (
+                      nowMs <
+                      createdAt.getTime() +
+                        self.options.requestIdExpirationPeriodMs
+                    )
+                      foundValidInResponseTo = true;
+                  }
+                  return Q.ninvoke(self.cacheProvider, "remove", inResponseTo);
+                })
+                .then(function() {
+                  if (!foundValidInResponseTo) {
+                    throw new Error("InResponseTo is not valid");
+                  }
+                  return Q();
+                });
+            }
           }
+        } else {
+          return Q.ninvoke(self.cacheProvider, "remove", inResponseTo);
         }
       } else {
-        return Q.ninvoke(self.cacheProvider, 'remove', inResponseTo);
+        return Q();
       }
-    } else {
-      return Q();
-    }
-  })
-  .then(function(){
-    var conditions = assertion.Conditions ? assertion.Conditions[0] : null;
-    if (assertion.Conditions && assertion.Conditions.length > 1) {
-      msg = 'Unable to process multiple conditions in SAML assertion';
-      throw new Error(msg);
-    }
-    if(conditions && conditions.$) {
-      var conErr = self.checkTimestampsValidityError(
-                    nowMs, conditions.$.NotBefore, conditions.$.NotOnOrAfter);
-      if(conErr)
-        throw conErr;
-    }
-    
-    if (self.options.audience) {
-      var audienceErr = self.checkAudienceValidityError(
-                    self.options.audience, conditions.AudienceRestriction);
-      if(audienceErr)
-        throw audienceErr;
-    }
+    })
+    .then(function() {
+      var conditions = assertion.Conditions ? assertion.Conditions[0] : null;
+      if (assertion.Conditions && assertion.Conditions.length > 1) {
+        msg = "Unable to process multiple conditions in SAML assertion";
+        throw new Error(msg);
+      }
+      if (conditions && conditions.$) {
+        var conErr = self.checkTimestampsValidityError(
+          nowMs,
+          conditions.$.NotBefore,
+          conditions.$.NotOnOrAfter
+        );
+        if (conErr) throw conErr;
+      }
 
-    var attributeStatement = assertion.AttributeStatement;
-    if (attributeStatement) {
-      var attributes = [].concat.apply([], attributeStatement.filter(function (attr) {
-        return Array.isArray(attr.Attribute);
-      }).map(function (attr) {
-        return attr.Attribute;
-      }));
+      if (self.options.audience) {
+        var audienceErr = self.checkAudienceValidityError(
+          self.options.audience,
+          conditions.AudienceRestriction
+        );
+        if (audienceErr) throw audienceErr;
+      }
 
-      var attrValueMapper = function(value) {
-        return typeof value === 'string' ? value : value._;
+      var attributeStatement = assertion.AttributeStatement;
+      if (attributeStatement) {
+        var attributes = [].concat.apply(
+          [],
+          attributeStatement
+            .filter(function(attr) {
+              return Array.isArray(attr.Attribute);
+            })
+            .map(function(attr) {
+              return attr.Attribute;
+            })
+        );
+
+        var attrValueMapper = function(value) {
+          return typeof value === "string" ? value : value._;
+        };
+
+        if (attributes) {
+          attributes.forEach(function(attribute) {
+            if (!attribute.hasOwnProperty("AttributeValue")) {
+              // if attributes has no AttributeValue child, continue
+              return;
+            }
+            var value = attribute.AttributeValue;
+            if (value.length === 1) {
+              profile[attribute.$.Name] = attrValueMapper(value[0]);
+            } else {
+              profile[attribute.$.Name] = value.map(attrValueMapper);
+            }
+          });
+        }
+      }
+
+      if (!profile.mail && profile["urn:oid:0.9.2342.19200300.100.1.3"]) {
+        // See http://www.incommonfederation.org/attributesummary.html for definition of attribute OIDs
+        profile.mail = profile["urn:oid:0.9.2342.19200300.100.1.3"];
+      }
+
+      if (!profile.email && profile.mail) {
+        profile.email = profile.mail;
+      }
+
+      profile.getAssertionXml = function() {
+        return xml;
       };
-
-      if (attributes) {
-        attributes.forEach(function (attribute) {
-         if(!attribute.hasOwnProperty('AttributeValue')) {
-            // if attributes has no AttributeValue child, continue
-            return;
-          }
-          var value = attribute.AttributeValue;
-          if (value.length === 1) {
-            profile[attribute.$.Name] = attrValueMapper(value[0]);
-          } else {
-            profile[attribute.$.Name] = value.map(attrValueMapper);
-          }
-        });
-      }
-    }
-
-    if (!profile.mail && profile['urn:oid:0.9.2342.19200300.100.1.3']) {
-      // See http://www.incommonfederation.org/attributesummary.html for definition of attribute OIDs
-      profile.mail = profile['urn:oid:0.9.2342.19200300.100.1.3'];
-    }
-
-    if (!profile.email && profile.mail) {
-      profile.email = profile.mail;
-    }
-
-    profile.getAssertionXml = function() { return xml; };
-
-    callback(null, profile, false);
-  })
-  .fail(function(err) {
-    callback(err);
-  })
-  .done();
+      profile.getSamlResponse = function() {
+        return samlResponse;
+      };
+      callback(null, profile, false);
+    })
+    .fail(function(err) {
+      callback(err);
+    })
+    .done();
 };
 
-SAML.prototype.checkTimestampsValidityError = function(nowMs, notBefore, notOnOrAfter) {
+SAML.prototype.checkTimestampsValidityError = function(
+  nowMs,
+  notBefore,
+  notOnOrAfter
+) {
   var self = this;
-  if (self.options.acceptedClockSkewMs == -1)
-      return null;
+  if (self.options.acceptedClockSkewMs == -1) return null;
 
   if (notBefore) {
     var notBeforeMs = Date.parse(notBefore);
     if (nowMs + self.options.acceptedClockSkewMs < notBeforeMs)
-        return new Error('SAML assertion not yet valid');
+      return new Error("SAML assertion not yet valid");
   }
   if (notOnOrAfter) {
     var notOnOrAfterMs = Date.parse(notOnOrAfter);
     if (nowMs - self.options.acceptedClockSkewMs >= notOnOrAfterMs)
-      return new Error('SAML assertion expired');
+      return new Error("SAML assertion expired");
   }
 
   return null;
 };
 
-SAML.prototype.checkAudienceValidityError = function(expectedAudience, audienceRestrictions) {
+SAML.prototype.checkAudienceValidityError = function(
+  expectedAudience,
+  audienceRestrictions
+) {
   var self = this;
   if (!audienceRestrictions || audienceRestrictions.length < 1) {
-    return new Error('SAML assertion has no AudienceRestriction');
+    return new Error("SAML assertion has no AudienceRestriction");
   }
-  var errors = audienceRestrictions.map(function(restriction) {
-    if (!restriction.Audience || !restriction.Audience[0]) {
-      return new Error('SAML assertion AudienceRestriction has no Audience value');
-    }
-    if (restriction.Audience[0] !== expectedAudience) {
-      return new Error('SAML assertion audience mismatch');
-    }
-    return null;
-  }).filter(function(result) {
-    return result !== null;
-  });
+  var errors = audienceRestrictions
+    .map(function(restriction) {
+      if (!restriction.Audience || !restriction.Audience[0]) {
+        return new Error(
+          "SAML assertion AudienceRestriction has no Audience value"
+        );
+      }
+      if (restriction.Audience[0] !== expectedAudience) {
+        return new Error("SAML assertion audience mismatch");
+      }
+      return null;
+    })
+    .filter(function(result) {
+      return result !== null;
+    });
   if (errors.length > 0) {
     return errors[0];
   }
   return null;
 };
 
-SAML.prototype.validatePostRequest = function (container, callback) {
+SAML.prototype.validatePostRequest = function(container, callback) {
   var self = this;
-  var xml = new Buffer(container.SAMLRequest, 'base64').toString('utf8');
+  var xml = new Buffer(container.SAMLRequest, "base64").toString("utf8");
   var dom = new xmldom.DOMParser().parseFromString(xml);
   var parserConfig = {
     explicitRoot: true,
     tagNameProcessors: [xml2js.processors.stripPrefix]
   };
   var parser = new xml2js.Parser(parserConfig);
-  parser.parseString(xml, function (err, doc) {
+  parser.parseString(xml, function(err, doc) {
     if (err) {
       return callback(err);
     }
 
-    self.certsToCheck()
-    .then(function(certs) {
-      // Check if this document has a valid top-level signature
-      if (self.options.cert && !self.validateSignature(xml, dom.documentElement, certs)) {
-        return callback(new Error('Invalid signature'));
-      }
+    self
+      .certsToCheck()
+      .then(function(certs) {
+        // Check if this document has a valid top-level signature
+        if (
+          self.options.cert &&
+          !self.validateSignature(xml, dom.documentElement, certs)
+        ) {
+          return callback(new Error("Invalid signature"));
+        }
 
-      processValidlySignedPostRequest(self, doc, callback);
-    })
-    .fail(function(err) {
-      callback(err);
-    });
+        processValidlySignedPostRequest(self, doc, callback);
+      })
+      .fail(function(err) {
+        callback(err);
+      });
   });
 };
 
 function processValidlySignedPostRequest(self, doc, callback) {
-    var request = doc.LogoutRequest;
-    if (request) {
-      var profile = {};
-      if (request.$.ID) {
-          profile.ID = request.$.ID;
-      } else {
-        return callback(new Error('Missing SAML LogoutRequest ID'));
-      }
-      var issuer = request.Issuer;
-      if (issuer) {
-        profile.issuer = issuer[0];
-      } else {
-        return callback(new Error('Missing SAML issuer'));
-      }
-
-      var nameID = request.NameID;
-      if (nameID) {
-        profile.nameID = nameID[0]._ || nameID[0];
-
-        if (nameID[0].$ && nameID[0].$.Format) {
-          profile.nameIDFormat = nameID[0].$.Format;
-        }
-      } else {
-        return callback(new Error('Missing SAML NameID'));
-      }
-      var sessionIndex = request.SessionIndex;
-      if (sessionIndex) {
-        profile.sessionIndex = sessionIndex[0];
-      }
-
-      callback(null, profile, true);
+  var request = doc.LogoutRequest;
+  if (request) {
+    var profile = {};
+    if (request.$.ID) {
+      profile.ID = request.$.ID;
     } else {
-      return callback(new Error('Unknown SAML request message'));
+      return callback(new Error("Missing SAML LogoutRequest ID"));
     }
+    var issuer = request.Issuer;
+    if (issuer) {
+      profile.issuer = issuer[0];
+    } else {
+      return callback(new Error("Missing SAML issuer"));
+    }
+
+    var nameID = request.NameID;
+    if (nameID) {
+      profile.nameID = nameID[0]._ || nameID[0];
+
+      if (nameID[0].$ && nameID[0].$.Format) {
+        profile.nameIDFormat = nameID[0].$.Format;
+      }
+    } else {
+      return callback(new Error("Missing SAML NameID"));
+    }
+    var sessionIndex = request.SessionIndex;
+    if (sessionIndex) {
+      profile.sessionIndex = sessionIndex[0];
+    }
+
+    callback(null, profile, true);
+  } else {
+    return callback(new Error("Unknown SAML request message"));
+  }
 }
 
-SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
+SAML.prototype.generateServiceProviderMetadata = function(decryptionCert) {
   var metadata = {
-    'EntityDescriptor' : {
-      '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
-      '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
-      '@entityID': this.options.issuer,
-      '@ID': this.options.issuer.replace(/\W/g, '_'),
-      'SPSSODescriptor' : {
-        '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      },
+    EntityDescriptor: {
+      "@xmlns": "urn:oasis:names:tc:SAML:2.0:metadata",
+      "@xmlns:ds": "http://www.w3.org/2000/09/xmldsig#",
+      "@entityID": this.options.issuer,
+      "@ID": this.options.issuer.replace(/\W/g, "_"),
+      SPSSODescriptor: {
+        "@protocolSupportEnumeration": "urn:oasis:names:tc:SAML:2.0:protocol"
+      }
     }
   };
 
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
       throw new Error(
-        "Missing decryptionCert while generating metadata for decrypting service provider");
+        "Missing decryptionCert while generating metadata for decrypting service provider"
+      );
     }
 
-    decryptionCert = decryptionCert.replace( /-+BEGIN CERTIFICATE-+\r?\n?/, '' );
-    decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
-    decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
+    decryptionCert = decryptionCert.replace(/-+BEGIN CERTIFICATE-+\r?\n?/, "");
+    decryptionCert = decryptionCert.replace(/-+END CERTIFICATE-+\r?\n?/, "");
+    decryptionCert = decryptionCert.replace(/\r\n/g, "\n");
 
     metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
-      'ds:KeyInfo' : {
-        'ds:X509Data' : {
-          'ds:X509Certificate': {
-            '#text': decryptionCert
+      "ds:KeyInfo": {
+        "ds:X509Data": {
+          "ds:X509Certificate": {
+            "#text": decryptionCert
           }
         }
       },
-      'EncryptionMethod' : [
+      EncryptionMethod: [
         // this should be the set that the xmlenc library supports
-        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes256-cbc' },
-        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
-        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
+        { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc" },
+        { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes128-cbc" },
+        { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#tripledes-cbc" }
       ]
     };
   }
 
   if (this.options.logoutCallbackUrl) {
     metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
-      '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-      '@Location': this.options.logoutCallbackUrl
+      "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+      "@Location": this.options.logoutCallbackUrl
     };
   }
 
   metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
-    '@index': '1',
-    '@isDefault': 'true',
-    '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-    '@Location': this.getCallbackUrl({})
+    "@index": "1",
+    "@isDefault": "true",
+    "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+    "@Location": this.getCallbackUrl({})
   };
 
-  return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
+  return xmlbuilder
+    .create(metadata)
+    .end({ pretty: true, indent: "  ", newline: "\n" });
 };
 
 exports.SAML = SAML;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1400 @@
+{
+  "name": "passport-saml",
+  "version": "0.32.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "dev": true,
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "send": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "should": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
+      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "dev": true,
+      "requires": {
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lolex": "1.6.0",
+        "native-promise-only": "0.8.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.6"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
+      "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.0.tgz",
+      "integrity": "sha512-qC0vMFX6q6ee8JaoTF2Om1uL8KAV1ATUjVaHRxLiPJkIsp8JZl6ZjG0MIB+twZFLbi1vXj30rqj4zlqYiOS9xg==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml-crypto": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-0.10.1.tgz",
+      "integrity": "sha1-+DL3TM9W8kr8rhFjofyrRNlndKg=",
+      "requires": {
+        "xmldom": "0.1.19",
+        "xpath.js": "1.1.0"
+      },
+      "dependencies": {
+        "xmldom": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+          "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+        }
+      }
+    },
+    "xml-encryption": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-0.11.0.tgz",
+      "integrity": "sha1-RYwst9AwD/YtMEx06z3tCMqXRWs=",
+      "requires": {
+        "async": "2.6.0",
+        "ejs": "2.5.7",
+        "node-forge": "0.7.1",
+        "xmldom": "0.1.27",
+        "xpath": "0.0.24"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xpath": {
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
+      "integrity": "sha1-Gt4WLhzFI8jTn8fQavwW6iFvKfs="
+    },
+    "xpath.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passport-saml",
   "version": "0.32.1",
-  "license" : "MIT",
+  "license": "MIT",
   "keywords": [
     "saml",
     "adfs",


### PR DESCRIPTION
I used this library to sign in users to my application using ADFS. I wanted to implement a feature where in users would use AWS `assume-role` feature to get temporary credentials to query for AWS resources. When I need to make api call to AWS for `assume-role` ([assume-role-documentation](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-saml.html)) I need to pass the full SAML response given by ADFS. `passport-saml`s `profile.getAssertionXml()` would return me only assertion xml. where in `profile.getSamlResponse` will be returning the whole `SAML` response