### PR TITLE
Add xml signature to HTTP POST AuthnRequest

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -208,7 +208,36 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
       request['samlp:AuthnRequest']['@ProviderName'] = self.options.providerName;
     }
 
-    callback(null, xmlbuilder.create(request).end());
+    var generatedRequest = xmlbuilder.create(request).end();
+
+    //Sign the POST Authn request if certificate is here
+    if (self.options.privateCert && self.options.authnRequestBinding==='HTTP-POST') {
+      try {
+        samlMessage = {};
+        samlMessage.toSign = generatedRequest;
+        switch (self.options.signatureAlgorithm) {
+          case 'sha256':
+            samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+            break;
+          case 'sha512':
+            samlMessage.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+            break;
+          default:
+            samlMessage.SigAlg = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
+            break;
+        }
+        var signedXml = new xmlCrypto.SignedXml();
+        signedXml.signatureAlgorithm = samlMessage.SigAlg;
+        signedXml.addReference("/samlp:AuthnRequest", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#'], 'http://www.w3.org/2001/04/xmlenc#sha256');
+        signedXml.signingKey = self.options.privateCert;
+        signedXml.computeSignature(samlMessage.toSign);
+        generatedRequest = signedXml.getSignedXml();
+
+      } catch (ex) {
+        return callback(ex);
+      }
+    }
+    callback(null, generatedRequest);
   })
   .fail(function(err){
     callback(err);
@@ -830,7 +859,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       if(conErr)
         throw conErr;
     }
-    
+
     if (self.options.audience) {
       var audienceErr = self.checkAudienceValidityError(
                     self.options.audience, conditions.AudienceRestriction);

--- a/test/static/AuthnRequestPostSha1
+++ b/test/static/AuthnRequestPostSha1
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_12345678901234567890" Version="2.0" IssueInstant="2014-05-28T00:13:09.000Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://relyingparty/adfs/postResponse" Destination="https://adfs.acme_tools.com/adfs/ls/">
+<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+acme_tools_com</saml:Issuer>
+<samlp:RequestedAuthnContext xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Comparison="exact">
+<saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password</saml:AuthnContextClassRef>
+</samlp:RequestedAuthnContext>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+<Reference URI="#_12345678901234567890">
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+<DigestValue>
+I5sUbdzY5j+6EArRiVKCAQ1shrksFgiPF3ZI2W0t2UU=</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>
+MWMBR24noTSmRaA5B79njzWPi9yMgHQkP5vnk8qdBwKHvoH1J6NUZqiTpi7izS3m/7LAFzEeprV1GIupqvfa1HrNa6zdxfY1BkSa8UBkUXPE/W/zzaU0uiEDPh7ps8USqsf8Ly8pHUlQCM1bj9YlPfkyaTtQX+r0kgHukT7TSiI27sYPBMbv04VQ/sndBU5cNKa9IDfO0SNytOKhM4x9uwyT1Q+zT9mjAcSTMG4/qHqzuRn/n9Q0qLGB3/hPuauxPKr35T7kPWz2TszYYf1SwpcdpCnlsPiqoWLFCHle4ooYAZfhtkD0a/opakCcBJ2fJorP9i7up7w7f653bhbpVg==</SignatureValue>
+</Signature>
+</samlp:AuthnRequest>

--- a/test/static/AuthnRequestPostSha256
+++ b/test/static/AuthnRequestPostSha256
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_12345678901234567890" Version="2.0" IssueInstant="2014-05-28T00:13:09.000Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://relyingparty/adfs/postResponse" Destination="https://adfs.acme_tools.com/adfs/ls/">
+<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+acme_tools_com</saml:Issuer>
+<samlp:RequestedAuthnContext xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Comparison="exact">
+<saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password</saml:AuthnContextClassRef>
+</samlp:RequestedAuthnContext>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+<Reference URI="#_12345678901234567890">
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+<DigestValue>
+I5sUbdzY5j+6EArRiVKCAQ1shrksFgiPF3ZI2W0t2UU=</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>
+GAHPaW3Cuf51hBjGCOA+EZElZbbR1NVJFyMbe3t4jo+eKSz5zbR1QxdtheRkZM/DhWY/fjNazzeBvwBs0+yXH6FyOF7/XriXFpAwpv/E+wrlugkoZTxIXB74FqZ/8uhvXDltSaO/EL+lCp+L+lEA783qmEDMU+HNV1aH6Pd1nAp93T8899mk0G33ASZw0xwY5Ap3UBbpD3v9fejC0is+4mF0E8TbVbcKymrl16BlcbUrCaFNepgskOwfR/Za9CMdnH2M/DFzzH2ONZmZY6hKkWu3jSKkCz1Yz08Qf077ns61gHOyTOltPP1g1H3v2erXVj7JOgMqPjNVLYiDmXAPmg==</SignatureValue>
+</Signature>
+</samlp:AuthnRequest>

--- a/test/static/AuthnRequestPostSha512
+++ b/test/static/AuthnRequestPostSha512
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_12345678901234567890" Version="2.0" IssueInstant="2014-05-28T00:13:09.000Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://relyingparty/adfs/postResponse" Destination="https://adfs.acme_tools.com/adfs/ls/">
+<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+acme_tools_com</saml:Issuer>
+<samlp:RequestedAuthnContext xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Comparison="exact">
+<saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password</saml:AuthnContextClassRef>
+</samlp:RequestedAuthnContext>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+<Reference URI="#_12345678901234567890">
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+<DigestValue>
+I5sUbdzY5j+6EArRiVKCAQ1shrksFgiPF3ZI2W0t2UU=</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>
+ENel/HkFSTad20mr3BQcR7Pxd2S1Z4sCcGVUVA3mcqYzrdzt5psWU5F1MKP1xE+74Q9lqAtzcrLToqZH7/7aE5j3MKqRTUxPslBMhIaujJov/XBba/DhyAUXGL/OGnWsT8CYv6gKz8XB1h/CI03exA0415Pn453GRtKuinmICUDGqjkZCcklCOHb170nMKNqxe+3WCWctSLasazX9+1SsaWkbleSqIBzthdny3VPi+LS8WwEULmE8sIkjv2lB4EEBQ8MvT/68EGqzdkIdEe5XIDp+m5r1MvxO22R6hKBwR6O1K/j79OkylY55NyRra3uyOofDaENdi6OkONZuPhtCA==</SignatureValue>
+</Signature>
+</samlp:AuthnRequest>

--- a/test/tests.js
+++ b/test/tests.js
@@ -948,7 +948,7 @@ describe( 'passport-saml /', function() {
             done();
           });
         });
-  
+
         it( 'cert as a function should validate with the returned cert', function( done ) {
           var functionCertSamlConfig = {
             entryPoint: samlConfig.entryPoint,
@@ -966,7 +966,7 @@ describe( 'passport-saml /', function() {
             done();
           });
         });
-  
+
         it( 'cert as a function should validate with one of the returned certs', function( done ) {
           var functionMultiCertSamlConfig = {
             entryPoint: samlConfig.entryPoint,
@@ -1018,6 +1018,80 @@ describe( 'passport-saml /', function() {
       });
       afterEach(function(){
           fakeClock.restore();
+      });
+
+      it( 'acme_tools POST AuthnRequest signed with sha1', function( done ) {
+        var samlConfig = {
+          entryPoint: 'https://adfs.acme_tools.com/adfs/ls/',
+          issuer: 'acme_tools_com',
+          callbackUrl: 'https://relyingparty/adfs/postResponse',
+          privateCert: fs.readFileSync(__dirname + '/static/acme_tools_com.key', 'utf-8'),
+          authnContext: 'http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password',
+          identifierFormat: null,
+          authnRequestBinding: 'HTTP-POST',
+          skipRequestCompression: false
+        };
+        var samlObj = new SAML( samlConfig );
+        samlObj.generateUniqueID = function () { return '12345678901234567890' };
+        var expectedHtml = fs.readFileSync(__dirname + '/static/AuthnRequestPostSha1', 'utf-8');
+        samlObj.generateAuthorizeRequest(null,false, (err, request)=>{
+          if(err){
+            done(err)
+          } else {
+            request.toString().replace(/>/g,'>\n').split('\n').should.eql(expectedHtml.split('\n'))
+            done()
+          }
+        })
+      });
+
+      it( 'acme_tools POST AuthnRequest signed with sha256', function( done ) {
+        var samlConfig = {
+          entryPoint: 'https://adfs.acme_tools.com/adfs/ls/',
+          issuer: 'acme_tools_com',
+          callbackUrl: 'https://relyingparty/adfs/postResponse',
+          privateCert: fs.readFileSync(__dirname + '/static/acme_tools_com.key', 'utf-8'),
+          authnContext: 'http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password',
+          identifierFormat: null,
+          signatureAlgorithm: 'sha256',
+          authnRequestBinding: 'HTTP-POST',
+          skipRequestCompression: false
+        };
+        var samlObj = new SAML( samlConfig );
+        samlObj.generateUniqueID = function () { return '12345678901234567890' };
+        var expectedHtml = fs.readFileSync(__dirname + '/static/AuthnRequestPostSha256', 'utf-8');
+        samlObj.generateAuthorizeRequest(null,false, (err, request)=>{
+          if(err){
+            done(err)
+          } else {
+            request.toString().replace(/>/g,'>\n').split('\n').should.eql(expectedHtml.split('\n'))
+            done()
+          }
+        })
+      });
+
+      it( 'acme_tools POST AuthnRequest signed with sha512', function( done ) {
+        var samlConfig = {
+          entryPoint: 'https://adfs.acme_tools.com/adfs/ls/',
+          issuer: 'acme_tools_com',
+          callbackUrl: 'https://relyingparty/adfs/postResponse',
+          privateCert: fs.readFileSync(__dirname + '/static/acme_tools_com.key', 'utf-8'),
+          authnContext: 'http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password',
+          identifierFormat: null,
+          signatureAlgorithm: 'sha512',
+          authnRequestBinding: 'HTTP-POST',
+          skipRequestCompression: false
+        };
+        var samlObj = new SAML( samlConfig );
+        samlObj.generateUniqueID = function () { return '12345678901234567890' };
+        var expectedHtml = fs.readFileSync(__dirname + '/static/AuthnRequestPostSha512', 'utf-8');
+        samlObj.generateAuthorizeRequest(null,false, (err, request)=>{
+          if(err){
+            done(err)
+          } else {
+            request.toString().replace(/>/g,'>\n').split('\n').should.eql(expectedHtml.split('\n'))
+            done()
+          }
+        })
       });
 
       it( 'acme_tools request signed with sha256', function( done ) {


### PR DESCRIPTION
As per SAML RFP, the signature in a HTTP-POST have to be included inside the xml.