### PR TITLE
Throw an error if validateInResponseTo is set and the InResponseTo attribute is missing

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -561,6 +561,8 @@ SAML.prototype.validatePostResponse = function (container, callback) {
               throw new Error('InResponseTo is not valid');
             return Q();
           });
+      } else {
+        throw new Error('InResponseTo is missing');
       }
     } else {
       return Q();


### PR DESCRIPTION
As raised here: https://github.com/bergie/passport-saml/issues/284

Setting `validateInResponseTo` to `true` should mean that the InResponseTo attribute missing is not valid.

This would be a valid example (if `_asdasdasd` was a valid id)
```xml
<saml2:Subject xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">person@place</saml2:NameID>
      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
            <saml2:SubjectConfirmationData InResponseTo="_asdasdasd" NotOnOrAfter="2018-06-05T22:55:08.344Z" Recipient="https://someapp/login/saml"/>
      </saml2:SubjectConfirmation>
</saml2:Subject>
```

This would be an invalid example
```xml
<saml2:Subject xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">person@place</saml2:NameID>
      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
            <saml2:SubjectConfirmationData NotOnOrAfter="2018-06-05T22:55:08.344Z" Recipient="https://someapp/login/saml"/>
      </saml2:SubjectConfirmation>
</saml2:Subject>
```
