### PR TITLE
added namespace md: for metadata elements

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -965,17 +965,18 @@ function processValidlySignedPostRequest(self, doc, callback) {
 }
 
 SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
-  var metadata = {
-    'EntityDescriptor' : {
-      '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
-      '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
-      '@entityID': this.options.issuer,
-      '@ID': this.options.issuer.replace(/\W/g, '_'),
-      'SPSSODescriptor' : {
-        '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      },
-    }
-  };
+
+  var root = {'md:EntityDescriptor' : {
+    '@xmlns:md': 'urn:oasis:names:tc:SAML:2.0:metadata',
+    '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
+    '@entityID': this.options.issuer,
+    '@ID': this.options.issuer.replace(/\W/g, '_'),
+  }};
+  var doc = xmlbuilder.create(root);
+  var SP = {'md:SPSSODescriptor' : {
+    '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
+  }};
+  doc.ele(SP);
 
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
@@ -987,7 +988,8 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
     decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
     decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
 
-    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
+
+    var K = { 'md:KeyDescriptor' : {
       'ds:KeyInfo' : {
         'ds:X509Data' : {
           'ds:X509Certificate': {
@@ -995,31 +997,38 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
           }
         }
       },
-      'EncryptionMethod' : [
+      'md:EncryptionMethod' : [
         // this should be the set that the xmlenc library supports
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes256-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
       ]
-    };
+    }};
+    doc.ele(K);
   }
 
   if (this.options.logoutCallbackUrl) {
-    metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
+    var L = {'md:SingleLogoutService' : {
       '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
       '@Location': this.options.logoutCallbackUrl
-    };
+    }};
+    doc.ele(L);
   }
 
-  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
-  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
+  var N = { 'md:NameIDFormat' : this.options.identifierFormat};
+  doc.ele(N);
+
+  var S = { 'md:AssertionConsumerService' : {
     '@index': '1',
     '@isDefault': 'true',
     '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
     '@Location': this.getCallbackUrl({})
-  };
+  }};
+  doc.ele(S);
 
-  return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
+
+  var ret = doc.end({ pretty: true, indent: '  ', newline: '\n' });
+  return ret;
 };
 
 exports.SAML = SAML;


### PR DESCRIPTION
Thanks for creating this lib.  I am using it for an automated service which reads the metadata output.  Unfortunately, your lib does not provide the namespace prefix for the root metadata namespace.  So I updated the metadata function to insert the "md:" prefix.  I already accept other metadata xml files such as from modules like simplesaml and they provide the md: namespace prefix which allows my service to parse the metadata file to auto provision trust with our IDP.  I hope this is useful for others and I hope it doesn't break any one elses code.