### PR TITLE
feat(logout): handle null and undefined on nameQualifier

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -239,11 +239,11 @@ SAML.prototype.generateLogoutRequest = function (req) {
     }
   };
 
-  if (typeof(req.user.nameQualifier) !== 'undefined') {
+  if (req.user.nameQualifier != null) {
     request['samlp:LogoutRequest']['saml:NameID']['@NameQualifier'] = req.user.nameQualifier;
   }
 
-  if (typeof(req.user.spNameQualifier) !== 'undefined') {
+  if (req.user.spNameQualifier != null) {
     request['samlp:LogoutRequest']['saml:NameID']['@SPNameQualifier'] = req.user.spNameQualifier;
   }
 


### PR DESCRIPTION
microsoft outlook returns

`nameQualifier`
`spNameQualifier`

as `null` instead of `undefined`

so this PR address this to handle both null and undefined