### PR TITLE
Create a way to get provider metadata when using the MultiSamlStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ The `decryptionCert` argument should be a public certificate matching the `decry
 
 The `signingCert` argument should be a public certificate matching the `privateCert` and is required if the strategy is configured with a `privateCert`.
 
+The `generateServiceProviderMetadata` method is also available on the `MultiSamlStrategy`, but needs an extra request and a callback argument (`generateServiceProviderMetadata( req, decryptionCert, signingCert, next )`), which are passed to the `getSamlOptions` to retrieve the correct configuration.
+
 
 ## Security and signatures
 

--- a/multiSamlStrategy.js
+++ b/multiSamlStrategy.js
@@ -39,4 +39,17 @@ MultiSamlStrategy.prototype.logout = function (req, options) {
   });
 };
 
+MultiSamlStrategy.prototype.generateServiceProviderMetadata = function( req, decryptionCert, signingCert, next ) {
+  var self = this;
+
+  return this._getSamlOptions(req, function (err, samlOptions) {
+    if (err) {
+      return next(err);
+    }
+
+    self._saml = new saml.SAML(samlOptions);
+    return next(null, self.constructor.super_.prototype.generateServiceProviderMetadata.call(self, decryptionCert, signingCert ));
+  });
+};
+
 module.exports = MultiSamlStrategy;

--- a/test/multiSamlStrategy.js
+++ b/test/multiSamlStrategy.js
@@ -149,3 +149,72 @@ describe('strategy#logout', function() {
     strategy.logout();
   });
 });
+
+describe('strategy#generateServiceProviderMetadata', function() {
+  beforeEach(function() {
+    this.superGenerateServiceProviderMetadata = sinon.stub(SamlStrategy.prototype, 'generateServiceProviderMetadata').returns('My Metadata Result');
+  });
+
+  afterEach(function() {
+    this.superGenerateServiceProviderMetadata.restore();
+  });
+
+  it('calls super with request and generateServiceProviderMetadata options', function(done) {
+    var superGenerateServiceProviderMetadata = this.superGenerateServiceProviderMetadata;
+    function getSamlOptions (req, fn) {
+      fn();
+      sinon.assert.calledOnce(superGenerateServiceProviderMetadata);
+      superGenerateServiceProviderMetadata.calledWith('bar', 'baz');
+      req.should.eql('foo');
+      done();
+    };
+
+
+    var strategy = new MultiSamlStrategy({ getSamlOptions: getSamlOptions }, verify);
+    strategy.generateServiceProviderMetadata('foo', 'bar', 'baz', function () {});
+  });
+
+  it('passes options on to saml strategy', function(done) {
+    var passportOptions = {
+      passReqToCallback: true,
+      authnRequestBinding: 'HTTP-POST',
+      getSamlOptions: function (req, fn) {
+        fn();
+        strategy._passReqToCallback.should.eql(true);
+        strategy._authnRequestBinding.should.eql('HTTP-POST');
+        done();
+      }
+    };
+
+    var strategy = new MultiSamlStrategy(passportOptions, verify);
+    strategy.generateServiceProviderMetadata('foo', 'bar', 'baz', function () {});
+  });
+
+  it('should pass error to callback function', function(done) {
+    var passportOptions = {
+      getSamlOptions: function (req, fn) {
+        fn('My error');
+      }
+    };
+
+    var strategy = new MultiSamlStrategy(passportOptions, verify);
+    strategy.generateServiceProviderMetadata('foo', 'bar', 'baz', function (error, result) {
+      should(error).equal('My error');
+      done();
+    });
+  });
+
+  it('should pass result to callback function', function(done) {
+    var passportOptions = {
+      getSamlOptions: function (req, fn) {
+        fn();
+      }
+    };
+
+    var strategy = new MultiSamlStrategy(passportOptions, verify);
+    strategy.generateServiceProviderMetadata('foo', 'bar', 'baz', function (error, result) {
+      should(result).equal('My Metadata Result');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This adds a function to pass in a request along with the other `generateServiceProviderMetadata` arguments to retrieve provider metadata when using the MultiSamlStrategy. If there is no request, we cannot call the `_getSamlOptions`-function to retrieve all the necessary options to call the `generateServiceProviderMetadata`-function with.