### PR TITLE
Fix #128 documentation for body-parser dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,13 @@ type Profile = {
 
 You need to provide a route corresponding to the `path` configuration parameter given to the strategy:
 
+The authentication callback must be invoked after the `body-parser` middlerware.
+
 ```javascript
+const bodyParser = require('body-parser');
+
 app.post('/login/callback',
+  bodyParser.urlencoded({ extended: false }),
   passport.authenticate('saml', { failureRedirect: '/', failureFlash: true }),
   function(req, res) {
     res.redirect('/');


### PR DESCRIPTION
If the body parser is not used, the authentication callback will fail to find request.body, forcing it to redirect to IDP entry point. Which then POSTs to callback URL and hence the infinite redirect continues.
