### PR TITLE
Add SamlResponseXML method to profile object

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ type Profile = {
   email?: string;  // `mail` if not present in the assertion
   getAssertionXml(): string;  // get the raw assertion XML
   getAssertion(): object;  // get the assertion XML parsed as a JavaScript object
+  getSamlResponseXml(): string; // get the raw SAML response XML
   ID?: string;
 } & {
   [attributeName: string]: string;  // arbitrary `AttributeValue`s

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -608,7 +608,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
           !self.validateSignature(xml, assertions[0], certs)) {
         throw new Error('Invalid signature');
       }
-      return self.processValidlySignedAssertion(assertions[0].toString(), inResponseTo, callback);
+      return self.processValidlySignedAssertion(assertions[0].toString(), xml, inResponseTo, callback);
     }
 
     if (encryptedAssertions.length == 1) {
@@ -630,7 +630,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
               !self.validateSignature(decryptedXml, decryptedAssertions[0], certs))
             throw new Error('Invalid signature from encrypted assertion');
 
-          self.processValidlySignedAssertion(decryptedAssertions[0].toString(), inResponseTo, callback);
+          self.processValidlySignedAssertion(decryptedAssertions[0].toString(), xml, inResponseTo, callback);
         });
     }
 
@@ -860,7 +860,7 @@ SAML.prototype.verifyIssuer = function (samlMessage) {
   }
 };
 
-SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callback) {
+SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, inResponseTo, callback) {
   var self = this;
   var msg;
   var parserConfig = {
@@ -1023,6 +1023,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
 
     profile.getAssertionXml = function() { return xml; };
     profile.getAssertion = function() { return parsedAssertion; };
+    profile.getSamlResponseXml = function() { return samlResponseXml; };
 
     callback(null, profile, false);
   })


### PR DESCRIPTION
This add the ability to extract the original SamlResponseXML as a method in the profile object.

Closes #328