### PR TITLE
Upgrade xml-crypto to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "debug": "^3.1.0",
     "passport-strategy": "*",
     "q": "^1.5.0",
-    "xml-crypto": "^1.0.2",
+    "xml-crypto": "^1.1.2",
     "xml-encryption": "^0.11.0",
     "xml2js": "0.4.x",
     "xmlbuilder": "^9.0.4",


### PR DESCRIPTION
This change incorporates a revert that fixes the problem discussed on 
yaronn/xml-crypto#167. It also drops xpath.js in favour of xpath, which
everybody else uses.

Fixes #324