### PR TITLE
Set explicitChar: true to make XML parsing consistent. Fixes issue #283 and #187

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .tern-port
+.idea

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -739,6 +739,7 @@ SAML.prototype.validateRedirect = function(container, callback) {
     var dom = new xmldom.DOMParser().parseFromString(inflated.toString());
     var parserConfig = {
       explicitRoot: true,
+      explicitCharKey: true,
       tagNameProcessors: [xml2js.processors.stripPrefix]
     };
     var parser = new xml2js.Parser(parserConfig);
@@ -855,8 +856,8 @@ SAML.prototype.verifyIssuer = function (samlMessage) {
   if(this.options.idpIssuer) {
     var issuer = samlMessage.Issuer;
     if (issuer) {
-      if (issuer[0] !== this.options.idpIssuer && issuer[0]._ !== this.options.idpIssuer)
-        throw 'Unknown SAML issuer. Expected: ' + this.options.idpIssuer + ' Received: ' + issuer[0];
+      if (issuer[0]._ !== this.options.idpIssuer)
+        throw 'Unknown SAML issuer. Expected: ' + this.options.idpIssuer + ' Received: ' + issuer[0]._;
     } else {
       throw 'Missing SAML issuer';
     }
@@ -868,6 +869,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
   var msg;
   var parserConfig = {
     explicitRoot: true,
+    explicitCharkey: true,
     tagNameProcessors: [xml2js.processors.stripPrefix]
   };
   var nowMs = new Date().getTime();
@@ -881,8 +883,8 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
     assertion = doc.Assertion;
 
     var issuer = assertion.Issuer;
-    if (issuer) {
-      profile.issuer = issuer[0];
+    if (issuer && issuer[0]._) {
+      profile.issuer = issuer[0]._;
     }
 
     var authnStatement = assertion.AuthnStatement;
@@ -896,8 +898,8 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
     var subjectConfirmation, confirmData;
     if (subject) {
       var nameID = subject[0].NameID;
-      if (nameID) {
-        profile.nameID = nameID[0]._ || nameID[0];
+      if (nameID && nameID[0]._) {
+        profile.nameID = nameID[0]._;
 
         if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;
@@ -1061,10 +1063,10 @@ SAML.prototype.checkAudienceValidityError = function(expectedAudience, audienceR
     return new Error('SAML assertion has no AudienceRestriction');
   }
   var errors = audienceRestrictions.map(function(restriction) {
-    if (!restriction.Audience || !restriction.Audience[0]) {
+    if (!restriction.Audience || !restriction.Audience[0] || !restriction.Audience[0]._) {
       return new Error('SAML assertion AudienceRestriction has no Audience value');
     }
-    if (restriction.Audience[0] !== expectedAudience) {
+    if (restriction.Audience[0]._ !== expectedAudience) {
       return new Error('SAML assertion audience mismatch');
     }
     return null;
@@ -1083,6 +1085,7 @@ SAML.prototype.validatePostRequest = function (container, callback) {
   var dom = new xmldom.DOMParser().parseFromString(xml);
   var parserConfig = {
     explicitRoot: true,
+    explicitCharkey: true,
     tagNameProcessors: [xml2js.processors.stripPrefix]
   };
   var parser = new xml2js.Parser(parserConfig);
@@ -1116,15 +1119,15 @@ function processValidlySignedPostRequest(self, doc, callback) {
         return callback(new Error('Missing SAML LogoutRequest ID'));
       }
       var issuer = request.Issuer;
-      if (issuer) {
-        profile.issuer = issuer[0];
+      if (issuer && issuer[0]._) {
+        profile.issuer = issuer[0]._;
       } else {
         return callback(new Error('Missing SAML issuer'));
       }
 
       var nameID = request.NameID;
       if (nameID) {
-        profile.nameID = nameID[0]._ || nameID[0];
+        profile.nameID = nameID[0]._;
 
         if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;


### PR DESCRIPTION
By setting explicitChars to true whenever xml2js is used and always use ._ to access values incosistent checks for [0] and [0]._ are eliminated.

Not broken test that were not broken from before.

Could have set .$ and ._ to .attrs and .chars or something instead but to fix the inconsistensies in the issues this was not necessary.