### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ type Profile = {
   getSamlResponseXml(): string; // get the raw SAML response XML
   ID?: string;
 } & {
-  [attributeName: string]: string;  // arbitrary `AttributeValue`s
+  [attributeName: string]: unknown;  // arbitrary `AttributeValue`s
 }
 ```
 


### PR DESCRIPTION
Change attributeName to unknown type to allow for use-case described in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33950. For example, you may extend the Profile object with an attribute `roles` which is an array of string. Having unknown still allows for typing enforcement, and yet is flexible to allow for these use-cases