### PR TITLE
Adjust argument name to match `super`

### DIFF
--- a/multiSamlStrategy.js
+++ b/multiSamlStrategy.js
@@ -36,7 +36,7 @@ MultiSamlStrategy.prototype.authenticate = function (req, options) {
   });
 };
 
-MultiSamlStrategy.prototype.logout = function (req, options) {
+MultiSamlStrategy.prototype.logout = function (req, callback) {
   var self = this;
 
   this._options.getSamlOptions(req, function (err, samlOptions) {
@@ -45,7 +45,7 @@ MultiSamlStrategy.prototype.logout = function (req, options) {
     }
 
     self._saml = new saml.SAML(Object.assign({}, self._options, samlOptions));
-    self.constructor.super_.prototype.logout.call(self, req, options);
+    self.constructor.super_.prototype.logout.call(self, req, callback);
   });
 };
 


### PR DESCRIPTION
The MultiSamlStrategy had a mis-named argument. This isn't a functional problem, but is misleading to the consumer of the function who might be reading source code.