### PR TITLE
NameIDFormat fix

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1249,10 +1249,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert, signi
     };
   }
 
-  if (this.options.indentifierFormat) {
+  if (this.options.identifierFormat) {
     metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
   }
-  
+
   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
     '@index': '1',
     '@isDefault': 'true',

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1249,7 +1249,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert, signi
     };
   }
 
-  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
+  if (this.options.indentifierFormat) {
+    metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
+  }
+  
   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
     '@index': '1',
     '@isDefault': 'true',


### PR DESCRIPTION
https://github.com/bergie/passport-saml/issues/338

When identifierFormat: null the passport-saml generated metadata with a tag `<NameIDFormat/>` which causes an error in AD FS: `The value 'NameIDFormat' must be an absolute URI`.
Setting the identifierFormat: urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified allows importing the metadata file successfully.