### PR TITLE
use options.host for callbackUrl

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -103,12 +103,8 @@ SAML.prototype.getCallbackUrl = function (req) {
   if (this.options.callbackUrl) {
     return this.options.callbackUrl;
   } else {
-    var host;
-    if (req.headers) {
-      host = req.headers.host;
-    } else {
-      host = this.options.host;
-    }
+    // Use host from options unless it is the default (localhost)
+    var host = this.options.host && this.options.host !== 'localhost' ? this.options.host : req.headers.host;
     return this.getProtocol(req) + host + this.options.path;
   }
 };

--- a/test/samlTests.js
+++ b/test/samlTests.js
@@ -32,6 +32,47 @@ describe('SAML.js', function () {
       };
     });
 
+    describe('getCallbackUrl', function () {
+      describe('when callbackUrl and host/path not specified', function () {
+        it('returns callbackUrl based on request headers', function () {
+          var callbackUrl = saml.getCallbackUrl(req);
+          callbackUrl.should.equal('https://examplesp.com/saml/consume')
+        });
+      });
+
+      describe('when protocol, host, path specified', function () {
+        beforeEach(function () {
+          saml = new SAML({
+            entryPoint: 'https://exampleidp.com/path?key=value',
+            logoutUrl: 'https://exampleidp.com/path?key=value',
+            protocol: 'test-protocol://',
+            host: 'test-host',
+            path: '/test-path'
+          });
+        });
+
+        it('returns callbackUrl', function () {
+          var callbackUrl = saml.getCallbackUrl(req);
+          callbackUrl.should.equal('test-protocol://test-host/test-path')
+        });
+      });
+
+      describe('when callbackUrl specified', function () {
+        beforeEach(function () {
+          saml = new SAML({
+            entryPoint: 'https://exampleidp.com/path?key=value',
+            logoutUrl: 'https://exampleidp.com/path?key=value',
+            callbackUrl: 'http://fake-callback.com/url'
+          });
+        });
+
+        it('returns callbackUrl', function () {
+          var callbackUrl = saml.getCallbackUrl(req);
+          callbackUrl.should.equal('http://fake-callback.com/url')
+        });
+      });
+    });
+
     describe('getAuthorizeUrl', function () {
       it('calls callback with right host', function (done) {
         saml.getAuthorizeUrl(req, {}, function (err, target) {


### PR DESCRIPTION
When callbackUrl was not specified passport-saml would use the HOST value from the request (req.headers.host) instead of the host specified in options. This change uses the host from options unless it is "localhost" which is the default value for that option. In the case of "localhost" we will continue to use the req.headers.host value as before.