### PR TITLE
add useFriendlyNames config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ type Profile = {
   * `skipRequestCompression`: if set to true, the SAML request from the service provider won't be compressed.
   * `authnRequestBinding`: if set to `HTTP-POST`, will request authentication from IDP via HTTP POST binding, otherwise defaults to HTTP Redirect
   * `disableRequestACSUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
+  * `useFriendlyNames`: if truthy `FriendlyName` from assertion will be used instead of `Name` for profile property name
  * **InResponseTo Validation**
   * `validateInResponseTo`: if truthy, then InResponseTo will be validated from incoming SAML responses
   * `requestIdExpirationPeriodMs`: Defines the expiration time when a Request ID generated for a SAML request will not be valid if seen in a SAML response in the `InResponseTo` field.  Default is 8 hours.

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1031,10 +1031,11 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
             return;
           }
           var value = attribute.AttributeValue;
+          var name = self.options.useFriendlyNames && attribute.$.FriendlyName ? attribute.$.FriendlyName : attribute.$.Name;
           if (value.length === 1) {
-            profile[attribute.$.Name] = attrValueMapper(value[0]);
+            profile[name] = attrValueMapper(value[0]);
           } else {
-            profile[attribute.$.Name] = value.map(attrValueMapper);
+            profile[name] = value.map(attrValueMapper);
           }
         });
       }


### PR DESCRIPTION
Adds a new `useFriendlyNames` config option that when set to true will use the `FriendlyName` instead of `Name` for profile properties from the SAML assertion.

Fixes https://github.com/bergie/passport-saml/issues/282