### PR TITLE
Fix minimum version of Node.js in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.0"
+  - "8.10"
   - "stable"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.0"
+  - "8.0"
   - "stable"
 
 script:


### PR DESCRIPTION
Support for Node 6 was dropped in dd1699ac04ec3968f8a6c763138e6503e160eec4