### PR TITLE
feat: Replace all usage of Q with native promises

### DIFF
--- a/lib/passport-saml/q-shim.js
+++ b/lib/passport-saml/q-shim.js
@@ -2,6 +2,8 @@
  * A collection of Q-flavored helper functions implemented with native promises
  */
 
+/* global Promise */
+
 /**
  * Calls a function and casts the returned value to a promise
  * @param {function():any} fn

--- a/lib/passport-saml/q-shim.js
+++ b/lib/passport-saml/q-shim.js
@@ -1,0 +1,55 @@
+/**
+ * A collection of Q-flavored helper functions implemented with native promises
+ */
+
+/**
+ * Calls a function and casts the returned value to a promise
+ * @param {function():any} fn
+ * @returns {Promise<any>}
+ */
+function fcall(fn) {
+  try {
+    var result = fn();
+    return Promise.resolve(result);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}
+
+/**
+ * Calls a node-callback style function with provided arguments
+ * and casts the return value to a promise
+ * @returns {Promise<any>}
+ */
+function nfcall() {
+  var args = Array.prototype.slice.call(arguments);
+  var method = args[0];
+  var methodArgs = args.slice(1);
+  return new Promise(function (resolve, reject) {
+    var callback = function (err, res) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(res);
+    };
+
+    return method.apply(null, methodArgs.concat(callback));
+  });
+}
+
+/**
+ * Calls a node-callback style function bound to the provided object with provided arguments
+ * and casts the return value to a promise
+ * @returns {Promise<any>}
+ */
+function ninvoke() {
+  var target = arguments[0];
+  var methodName = arguments[1];
+  var args = Array.prototype.slice.call(arguments, 2);
+  var bound = target[methodName].bind(target);
+  return nfcall.apply(null, [bound].concat(args));
+}
+
+exports.fcall = fcall;
+exports.nfcall = nfcall;
+exports.ninvoke = ninvoke;

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -10,7 +10,10 @@ var xmlbuilder = require('xmlbuilder');
 var xmlenc = require('xml-encryption');
 var xpath = xmlCrypto.xpath;
 var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
-var Q = require('q');
+
+var fcall = require('./q-shim').fcall;
+var nfcall = require('./q-shim').nfcall;
+var ninvoke = require('./q-shim').ninvoke;
 
 var SAML = function (options) {
   this.options = this.initialize(options);
@@ -157,11 +160,11 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
   var instant = this.generateInstant();
   var forceAuthn = this.options.forceAuthn || false;
 
-  Q.fcall(() => {
+  fcall(() => {
     if(this.options.validateInResponseTo) {
-      return Q.ninvoke(this.cacheProvider, 'save', id, instant);
+      return ninvoke(this.cacheProvider, 'save', id, instant);
     } else {
-      return Q();
+      return Promise.resolve();
     }
   })
   .then(() => {
@@ -225,10 +228,9 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
 
     callback(null, xmlbuilder.create(request).end());
   })
-  .fail(function(err){
+  .catch(function(err){
     callback(err);
-  })
-  .done();
+  });
 };
 
 SAML.prototype.generateLogoutRequest = function (req) {
@@ -269,7 +271,7 @@ SAML.prototype.generateLogoutRequest = function (req) {
     };
   }
 
-  return Q.ninvoke(this.cacheProvider, 'save', id, instant)
+  return ninvoke(this.cacheProvider, 'save', id, instant)
     .then(function() {
       return xmlbuilder.create(request).end();
     });
@@ -303,7 +305,7 @@ SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
 };
 
 SAML.prototype.requestToUrl = function (request, response, operation, additionalParameters, callback) {
-  
+
   const requestToUrlHelper = (err, buffer) => {
     if (err) {
       return callback(err);
@@ -505,22 +507,22 @@ SAML.prototype.certToPEM = function (cert) {
 
 SAML.prototype.certsToCheck = function () {
   if (!this.options.cert) {
-    return Q();
+    return Promise.resolve();
   }
   if (typeof(this.options.cert) === 'function') {
-    return Q.nfcall(this.options.cert)
+    return nfcall(this.options.cert)
     .then(certs => {
       if (!Array.isArray(certs)) {
         certs = [certs];
       }
-      return Q(certs);
+      return Promise.resolve(certs);
     });
   }
   var certs = this.options.cert;
   if (!Array.isArray(certs)) {
     certs = [certs];
   }
-  return Q(certs);
+  return Promise.resolve(certs);
 };
 
 // This function checks that the |currentNode| in the |fullXml| document contains exactly 1 valid
@@ -537,7 +539,7 @@ SAML.prototype.validateSignature = function (fullXml, currentNode, certs) {
   if (signatures.length != 1) {
     return false;
   }
-  
+
   const signature = signatures[0];
   return certs.some(certToCheck => {
     return this.validateSignatureForCert(signature, certToCheck, fullXml, currentNode);
@@ -576,7 +578,7 @@ SAML.prototype.validateSignatureForCert = function (signature, cert, fullXml, cu
 SAML.prototype.validatePostResponse = function (container, callback) {
   var xml, doc, inResponseTo;
 
-  Q.fcall(() => {
+  fcall(() => {
     xml = Buffer.from(container.SAMLResponse, 'base64').toString('utf8');
     doc = new xmldom.DOMParser({
     }).parseFromString(xml);
@@ -626,7 +628,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
       var encryptedAssertionXml = encryptedAssertions[0].toString();
 
       var xmlencOptions = { key: this.options.decryptionPvk };
-      return Q.ninvoke(xmlenc, 'decrypt', encryptedAssertionXml, xmlencOptions)
+      return ninvoke(xmlenc, 'decrypt', encryptedAssertionXml, xmlencOptions)
       .then(decryptedXml => {
         var decryptedDoc = new xmldom.DOMParser().parseFromString(decryptedXml);
         var decryptedAssertions = xpath(decryptedDoc, "/*[local-name()='Assertion']");
@@ -651,7 +653,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
       tagNameProcessors: [xml2js.processors.stripPrefix]
     };
     var parser = new xml2js.Parser(parserConfig);
-    return Q.ninvoke( parser, 'parseString', xml)
+    return ninvoke( parser, 'parseString', xml)
     .then(doc => {
       var response = doc.Response;
       if (response) {
@@ -707,34 +709,33 @@ SAML.prototype.validatePostResponse = function (container, callback) {
         }
       });
   })
-  .fail(err => {
+  .catch(err => {
     debug('validatePostResponse resulted in an error: %s', err);
     if (this.options.validateInResponseTo) {
-      Q.ninvoke(this.cacheProvider, 'remove', inResponseTo)
+      ninvoke(this.cacheProvider, 'remove', inResponseTo)
       .then(function() {
         callback(err);
       });
     } else {
       callback(err);
     }
-  })
-  .done();
+  });
 };
 
 SAML.prototype.validateInResponseTo = function (inResponseTo) {
   if (this.options.validateInResponseTo) {
     if (inResponseTo) {
-      return Q.ninvoke(this.cacheProvider, 'get', inResponseTo)
+      return ninvoke(this.cacheProvider, 'get', inResponseTo)
         .then(result => {
           if (!result)
             throw new Error('InResponseTo is not valid');
-          return Q();
+          return Promise.resolve();
         });
     } else {
       throw new Error('InResponseTo is missing from response');
     }
   } else {
-    return Q();
+    return Promise.resolve();
   }
 };
 
@@ -759,13 +760,13 @@ SAML.prototype.validateRedirect = function(container, originalQuery, callback) {
         return callback(err);
       }
 
-      Q.fcall(() => {
+      fcall(() => {
         return samlMessageType === 'SAMLResponse' ?
           this.verifyLogoutResponse(doc) : this.verifyLogoutRequest(doc);
       })
       .then(() => this.hasValidSignatureForRedirect(container, originalQuery))
       .then(() => processValidlySignedSamlLogout(this, doc, callback))
-      .fail(err => callback(err));
+      .catch(err => callback(err));
     });
   });
 };
@@ -812,7 +813,7 @@ SAML.prototype.hasValidSignatureForRedirect = function (container, originalQuery
         }
       });
   } else {
-    return Q(true);
+    return Promise.resolve(true);
   }
 };
 
@@ -852,7 +853,7 @@ SAML.prototype.verifyLogoutRequest = function (doc) {
 };
 
 SAML.prototype.verifyLogoutResponse = function (doc) {
-  return Q.fcall(() => {
+  return fcall(() => {
     var statusCode = doc.LogoutResponse.Status[0].StatusCode[0].$.Value;
     if (statusCode !== "urn:oasis:names:tc:SAML:2.0:status:Success")
       throw 'Bad status code: ' + statusCode;
@@ -863,7 +864,7 @@ SAML.prototype.verifyLogoutResponse = function (doc) {
       return this.validateInResponseTo(inResponseTo);
     }
 
-    return Q(true);
+    return Promise.resolve(true);
   });
 };
 
@@ -891,7 +892,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
   var assertion;
   var parsedAssertion;
   var parser = new xml2js.Parser(parserConfig);
-  Q.ninvoke(parser, 'parseString', xml)
+  ninvoke(parser, 'parseString', xml)
   .then(doc => {
     parsedAssertion = doc;
     assertion = doc.Assertion;
@@ -904,7 +905,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
     if (inResponseTo) {
       profile.inResponseTo = inResponseTo;
     }
-    
+
     var authnStatement = assertion.AuthnStatement;
     if (authnStatement) {
       if (authnStatement[0].$ && authnStatement[0].$.SessionIndex) {
@@ -956,34 +957,34 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
         if (confirmData && confirmData.$) {
           var subjectInResponseTo = confirmData.$.InResponseTo;
           if (inResponseTo && subjectInResponseTo && subjectInResponseTo != inResponseTo) {
-            return Q.ninvoke(this.cacheProvider, 'remove', inResponseTo)
+            return ninvoke(this.cacheProvider, 'remove', inResponseTo)
               .then(() => {
                 throw new Error('InResponseTo is not valid');
               });
           } else if (subjectInResponseTo) {
             var foundValidInResponseTo = false;
-            return Q.ninvoke(this.cacheProvider, 'get', subjectInResponseTo)
+            return ninvoke(this.cacheProvider, 'get', subjectInResponseTo)
               .then(result => {
                 if (result) {
                   var createdAt = new Date(result);
                   if (nowMs < createdAt.getTime() + this.options.requestIdExpirationPeriodMs)
                     foundValidInResponseTo = true;
                 }
-                return Q.ninvoke(this.cacheProvider, 'remove', inResponseTo );
+                return ninvoke(this.cacheProvider, 'remove', inResponseTo );
               })
               .then(() => {
                 if (!foundValidInResponseTo) {
                   throw new Error('InResponseTo is not valid');
                 }
-                return Q();
+                return Promise.resolve();
               });
           }
         }
       } else {
-        return Q.ninvoke(this.cacheProvider, 'remove', inResponseTo);
+        return ninvoke(this.cacheProvider, 'remove', inResponseTo);
       }
     } else {
-      return Q();
+      return Promise.resolve();
     }
   })
   .then(() => {
@@ -1050,8 +1051,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
 
     callback(null, profile, false);
   })
-  .fail(err => callback(err))
-  .done();
+  .catch(err => callback(err));
 };
 
 SAML.prototype.checkTimestampsValidityError = function(nowMs, notBefore, notOnOrAfter) {
@@ -1116,7 +1116,7 @@ SAML.prototype.validatePostRequest = function (container, callback) {
 
       processValidlySignedPostRequest(this, doc, callback);
     })
-    .fail(err => callback(err));
+    .catch(err => callback(err));
   });
 };
 

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -11,6 +11,7 @@ var xmlenc = require('xml-encryption');
 var xpath = xmlCrypto.xpath;
 var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
 
+/* global Promise */
 var fcall = require('./q-shim').fcall;
 var nfcall = require('./q-shim').nfcall;
 var ninvoke = require('./q-shim').ninvoke;

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1158,7 +1158,7 @@ SAML.prototype.getNameID = function(self, doc, callback) {
     var encryptedDataXml = encryptedDatas[0].toString();
 
     var xmlencOptions = { key: self.options.decryptionPvk };
-    return Q.ninvoke(xmlenc, 'decrypt', encryptedDataXml, xmlencOptions)
+    return ninvoke(xmlenc, 'decrypt', encryptedDataXml, xmlencOptions)
       .then(function (decryptedXml) {
         var decryptedDoc = new xmldom.DOMParser().parseFromString(decryptedXml);
         var decryptedIds = xpath(decryptedDoc, "/*[local-name()='NameID']");

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "debug": "^3.1.0",
     "passport-strategy": "*",
-    "q": "^1.5.0",
     "xml-crypto": "^1.4.0",
     "xml-encryption": "^0.11.0",
     "xml2js": "0.4.x",


### PR DESCRIPTION
Replaces all usage of Q with native promises
- `Q.fcall Q.nfcall Q.ninvoke` replaced with native implementations
- `Q(val)` replaced with `Promise.resolve(val)`
- `.fail(err)` replaced with `.catch(err)`
- `.done()` dropped

Happy to reimplement with `async/await` `let/const` semantics or to use Bluebird's helpers instead.