### PR TITLE
attributeConsumingServiceIndex can be zero

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -205,7 +205,7 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, isHttpPostBi
       };
     }
 
-    if (this.options.attributeConsumingServiceIndex) {
+    if (this.options.attributeConsumingServiceIndex != null) {
       request['samlp:AuthnRequest']['@AttributeConsumingServiceIndex'] = this.options.attributeConsumingServiceIndex;
     }
 


### PR DESCRIPTION
The PR fixes a wrong check on attributeConsumingServiceIndex which can be zero.